### PR TITLE
fixes tab focus problems in firefox for pw reset and registration

### DIFF
--- a/src/app/shared/directives/disable-subscript-wrapper-tab-focus.ts
+++ b/src/app/shared/directives/disable-subscript-wrapper-tab-focus.ts
@@ -1,0 +1,30 @@
+import {
+    Directive, ElementRef, AfterViewInit
+} from '@angular/core';
+
+/**
+ * This directive fixes a firefox issue.
+ * Without it the user can use the tab to focus the multiline hint messages below the input fields
+ * see ticket #619
+ */
+@Directive({
+    selector: '[fclDisableSubscriptWrapperTabFocus]'
+})
+export class DisableSubscriptWrapperTabFocusDirective implements AfterViewInit {
+
+    constructor(
+        private hostElement: ElementRef
+    ) {}
+
+    // lifecycle hooks start
+
+    ngAfterViewInit(): void {
+        this.disableSubscriptWrapperTabFocus();
+    }
+    // lifecycle hooks end
+
+    private disableSubscriptWrapperTabFocus() {
+        const children: HTMLDivElement[] = this.hostElement.nativeElement.querySelectorAll('.mat-form-field-subscript-wrapper');
+        children.forEach(child => child.tabIndex = -1);
+    }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -7,6 +7,7 @@ import { SpinnerLoaderComponent } from './spinner-loader/spinner-loader.componen
 import { AlertComponent } from './alert/alert.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { SingleCenterCardLayoutComponent } from './presentation/single-center-card-layout/single-center-card-layout.component';
+import { DisableSubscriptWrapperTabFocusDirective } from './directives/disable-subscript-wrapper-tab-focus';
 
 @NgModule({
     imports: [
@@ -17,7 +18,8 @@ import { SingleCenterCardLayoutComponent } from './presentation/single-center-ca
     declarations: [
         SpinnerLoaderComponent,
         AlertComponent,
-        SingleCenterCardLayoutComponent
+        SingleCenterCardLayoutComponent,
+        DisableSubscriptWrapperTabFocusDirective
     ],
     exports: [
         FormsModule,
@@ -26,7 +28,8 @@ import { SingleCenterCardLayoutComponent } from './presentation/single-center-ca
         DragDropModule,
         SpinnerLoaderComponent,
         AlertComponent,
-        SingleCenterCardLayoutComponent
+        SingleCenterCardLayoutComponent,
+        DisableSubscriptWrapperTabFocusDirective
     ]
 })
 export class SharedModule { }

--- a/src/app/user/presentation/register/register.component.html
+++ b/src/app/user/presentation/register/register.component.html
@@ -4,7 +4,7 @@
     </ng-container>
 </ng-template>
 
-<form [formGroup]="registerForm" class="fcl-register-form" (ngSubmit)="onRegister()">
+<form [formGroup]="registerForm" class="fcl-register-form" (ngSubmit)="onRegister()" fclDisableSubscriptWrapperTabFocus>
     <div class="fcl-mat-card-content">
         <div class="form-group fcl-form-firstname">
             <mat-form-field class="fcl-form-field" appearance="standard">

--- a/src/app/user/presentation/register/register.component.ts
+++ b/src/app/user/presentation/register/register.component.ts
@@ -15,6 +15,7 @@ export class RegisterComponent implements OnInit {
     @Input() serverValidationErrors: Partial<Record<keyof RegistrationCredentials, ValidationError[]>> = {};
 
     @Output() register = new EventEmitter<RegistrationCredentials>();
+
     registerForm: FormGroup;
 
     ngOnInit() {

--- a/src/app/user/presentation/reset/reset.component.html
+++ b/src/app/user/presentation/reset/reset.component.html
@@ -1,4 +1,4 @@
-<form [formGroup]="resetForm" (ngSubmit)="onReset()">
+<form [formGroup]="resetForm" (ngSubmit)="onReset()" fclDisableSubscriptWrapperTabFocus>
     <div class="fcl-mat-card-content">
         <div class="fcl-reset-text">
             <div class="mat-subheading-2">Please enter a new password.</div>

--- a/src/app/user/presentation/reset/reset.component.ts
+++ b/src/app/user/presentation/reset/reset.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Output, EventEmitter, Input } from '@angular/core';
+import { Component, OnInit, Output, EventEmitter, Input, ElementRef } from '@angular/core';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { ValidationError } from '@app/core/model';
 import { NewPasswordRequestDTO } from '../../../user/models/user.model';
@@ -15,6 +15,8 @@ export class ResetComponent implements OnInit {
     @Output() reset = new EventEmitter<NewPasswordRequestDTO>();
 
     resetForm: FormGroup;
+
+    constructor(public elementRef: ElementRef) {}
 
     ngOnInit() {
         this.resetForm = new FormGroup({


### PR DESCRIPTION
- adds a new directive that sets the tabIndex to -1 for all child
elements with class .mat-form-field-subscript-wrapper

ticket: #619
Change-Id: I95027b71a8196fffb216b2912f7a41ac1495a12b