### PR TITLE
Change columns display names on station and delivery properties dialog.

### DIFF
--- a/src/app/tracing/dialog/delivery-properties/delivery-properties.component.html
+++ b/src/app/tracing/dialog/delivery-properties/delivery-properties.component.html
@@ -10,7 +10,12 @@
                     <td>{{properties[prop].label}}</td>
                     <td>{{properties[prop].value}}</td>
                 </tr>
-                <tr *ngFor="let prop of (!otherPropertiesHidden ? otherProperties : [])">
+                <tr *ngIf="!otherPropertiesHidden">
+                    <td colspan="2" class="fcl-delivery-properties-horizontal-line-cell">
+                        <hr class="fcl-delivery-properties-horizontal-line">
+                    </td>
+                </tr>
+                <tr *ngFor="let prop of (!otherPropertiesHidden ? getOtherPropertiesOri() : [])">
                     <td>{{properties[prop].label}}</td>
                     <td>{{properties[prop].value}}</td>
                 </tr>

--- a/src/app/tracing/dialog/delivery-properties/delivery-properties.component.scss
+++ b/src/app/tracing/dialog/delivery-properties/delivery-properties.component.scss
@@ -10,3 +10,12 @@
 td:first-child {
     padding-right: 40px;
 }
+
+td.fcl-delivery-properties-horizontal-line-cell {
+    padding: 0;
+}
+
+.fcl-delivery-properties-horizontal-line {
+    width: 100%;
+    margin: 1rem 0 1rem 0;
+}

--- a/src/app/tracing/dialog/station-properties/station-properties.component.html
+++ b/src/app/tracing/dialog/station-properties/station-properties.component.html
@@ -9,7 +9,12 @@
                     <td>{{properties[prop].label}}</td>
                     <td>{{properties[prop].value}}</td>
                 </tr>
-                <tr *ngFor="let prop of (!otherPropertiesHidden ? otherProperties : [])">
+                <tr *ngIf="!otherPropertiesHidden">
+                    <td colspan="2" class="fcl-station-properties-horizontal-line-cell">
+                        <hr class="fcl-station-properties-horizontal-line">
+                    </td>
+                </tr>
+                <tr *ngFor="let prop of (!otherPropertiesHidden ? getOtherPropertiesOri() : [])">
                     <td>{{properties[prop].label}}</td>
                     <td>{{properties[prop].value}}</td>
                 </tr>

--- a/src/app/tracing/dialog/station-properties/station-properties.component.scss
+++ b/src/app/tracing/dialog/station-properties/station-properties.component.scss
@@ -13,3 +13,12 @@ table {
 td:first-child {
     padding-right: 40px;
 }
+
+td.fcl-station-properties-horizontal-line-cell {
+    padding: 0;
+}
+
+.fcl-station-properties-horizontal-line {
+    width: 100%;
+    margin: 1rem 0 1rem 0;
+}

--- a/src/app/tracing/dialog/station-properties/station-properties.component.ts
+++ b/src/app/tracing/dialog/station-properties/station-properties.component.ts
@@ -2,7 +2,7 @@ import { Component, ElementRef, Inject, OnDestroy, OnInit, ViewChild } from '@an
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import * as d3 from 'd3';
 
-import { DeliveryData, StationData, DeliveryId, StationId } from '../../data.model';
+import { DeliveryData, StationData, DeliveryId, StationId, TableColumn } from '../../data.model';
 import { Constants } from '../../util/constants';
 import { Utils } from '../../util/non-ui-utils';
 import { State } from '@app/tracing/state/tracing.reducers';
@@ -13,6 +13,7 @@ export interface StationPropertiesData {
     station: StationData;
     deliveries: Map<DeliveryId, DeliveryData>;
     connectedStations: Map<StationId, StationData>;
+    stationColumns: TableColumn[];
 }
 
 type LotKey = string;
@@ -171,7 +172,7 @@ export class StationPropertiesComponent implements OnInit, OnDestroy {
         @Inject(MAT_DIALOG_DATA) public data: StationPropertiesData,
         private store: Store<State>
     ) {
-        this.initProperties(this.data.station);
+        this.initProperties(this.data.station, this.data.stationColumns);
 
         if (data.station.incoming.length > 0 || data.station.outgoing.length > 0) {
             const ingredientsByLotKey = this.getIngredientsByLotKey();
@@ -207,27 +208,38 @@ export class StationPropertiesComponent implements OnInit, OnDestroy {
         }
     }
 
-    private initProperties(station: StationData): void {
+    private initProperties(station: StationData, columns: TableColumn[]): void {
         const properties: Properties = {};
         const hiddenProps = Utils.createSimpleStringSet(this.notListedProps);
         Object.keys(station).filter(key => Constants.PROPERTIES.has(key) && !hiddenProps[key])
             .forEach(key => {
+                const column: TableColumn = columns.find(column => column.id === key);
+                const label = column !== undefined ? column.name : Constants.PROPERTIES.get(key).name;
                 const value = station[key];
                 properties[key] = {
-                    label: Constants.PROPERTIES.get(key).name,
+                    label: label,
                     value: value != null ? value + '' : ''
                 };
             });
 
         station.properties.forEach(prop => {
+            const column: TableColumn = columns.find(column => column.id === prop.name);
+            const label = column !== undefined ? column.name : this.convertPropNameToLabel(prop.name);
             properties[prop.name] = {
-                label: this.convertPropNameToLabel(prop.name),
+                label: label,
                 value: prop.value + ''
             };
         });
 
         const vipProps = Utils.createSimpleStringSet(this.vipProperties);
-        this.otherProperties = Object.keys(properties).filter(key => !vipProps[key]).slice();
+        this.otherProperties = Object
+            .keys(properties)
+            .filter(key => !vipProps[key])
+            .slice()
+            .map(property => {
+                const column: TableColumn = columns.find(column => column.id === property);
+                return column !== undefined ? column.name : Constants.PROPERTIES.get(property).name;
+            });
         this.otherProperties.sort();
         // add default for missing props
         this.vipProperties.filter(key => !properties[key]).forEach(key => {
@@ -297,6 +309,12 @@ export class StationPropertiesComponent implements OnInit, OnDestroy {
 
     toggleOtherProperties() {
         this.otherPropertiesHidden = !this.otherPropertiesHidden;
+    }
+
+    getOtherPropertiesOri() {
+        return this.otherProperties
+            .map(property => Object.keys(this.properties)
+                .find(key => this.properties[key].label === property));
     }
 
     private createDeliveryNode(deliveryId: DeliveryId): NodeDatum {

--- a/src/app/tracing/io/data-mappings/data-mappings-v1.ts
+++ b/src/app/tracing/io/data-mappings/data-mappings-v1.ts
@@ -129,7 +129,8 @@ export const DEFAULT_DELIVERY_PROP_INT_TO_EXT_MAP: ImmutableMap<
     score: ExtDataConstants.DELIVERY_SCORE,
     observed: ExtDataConstants.DELIVERY_OBSERVED,
     dateOut: ExtDataConstants.DELIVERY_OUT_DATE,
-    dateIn: ExtDataConstants.DELIVERY_IN_DATE
+    dateIn: ExtDataConstants.DELIVERY_IN_DATE,
+    amount: ExtDataConstants.DELIVERY_AMOUNT
 });
 
 export const DENOVO_DELIVERY_PROP_INT_TO_EXT_MAP: ImmutableMap<

--- a/src/app/tracing/io/ext-data-constants.v1.ts
+++ b/src/app/tracing/io/ext-data-constants.v1.ts
@@ -47,6 +47,7 @@ export const DELIVERY_LOT_SCORE = 'Lot Score';
 export const DELIVERY_NORM_SCORE = 'Normalized Score';
 export const DELIVERY_POS_SCORE = 'Positive Score';
 export const DELIVERY_NEG_SCORE = 'Negative Score';
+export const DELIVERY_AMOUNT = 'Amount';
 
 export const DEL2DEL_ID = 'ID';
 export const DEL2DEL_NEXT = 'Next';

--- a/src/app/tracing/services/table.service.ts
+++ b/src/app/tracing/services/table.service.ts
@@ -66,9 +66,7 @@ export class TableService {
             { id: 'killContamination', name: 'Kill Contamination' },
             { id: 'observed', name: 'Observed' },
             { id: 'forward', name: 'On Forward Trace' },
-            { id: 'Forward', name: 'On Forward Trace' },
             { id: 'backward', name: 'On Backward Trace' },
-            { id: 'Backward', name: 'On Backward Trace' },
             { id: 'score', name: 'Score' },
             { id: 'selected', name: 'Selected' },
             { id: 'invisible', name: 'Invisible' }
@@ -99,9 +97,7 @@ export class TableService {
 
         const additionalColumns: TableColumn[] = [
             { id: 'forward', name: 'On Forward Trace' },
-            { id: 'Forward', name: 'On Forward Trace' },
             { id: 'backward', name: 'On Backward Trace' },
-            { id: 'Backward', name: 'On Backward Trace' },
             { id: 'crossContamination', name: 'Cross Contamination' },
             { id: 'killContamination', name: 'Kill Contamination' },
             { id: 'observed', name: 'Observed' },
@@ -113,8 +109,11 @@ export class TableService {
             { id: 'contained', name: 'Is Meta Member' }
         ];
 
+        // the addColumnsForProperties method adds properties to the additionalColmns that are already present
+        // in the favoriteColumns which results finally in double entries
         this.addColumnsForProperties(additionalColumns, data.stations);
 
+        // double entries are removed in the mergeColumns method
         return this.mergeColumns(favoriteColumns, additionalColumns);
     }
 
@@ -124,7 +123,8 @@ export class TableService {
             ..._.sortBy(additionalColumns, [(columnItem: TableColumn) => columnItem.name.toLowerCase()])
         ];
 
-        return _.uniqBy(columns, (item: TableColumn) => item.id.replace(/\s/g, '').toLowerCase());
+        // uniqBy removes the double entries that were collected in the addColumnsForProperties method
+        return _.uniqBy(columns, (item: TableColumn) => item.id);
     }
 
     private addColumnsForProperties(columns: TableColumn[], arr: (StationData | DeliveryData)[]): void {

--- a/src/app/tracing/tracing.effects.ts
+++ b/src/app/tracing/tracing.effects.ts
@@ -9,7 +9,7 @@ import * as fromTracing from './state/tracing.reducers';
 import * as tracingSelectors from './state/tracing.selectors';
 import { mergeMap, withLatestFrom } from 'rxjs/operators';
 import { EMPTY, of } from 'rxjs';
-import { DeliveryData, DeliveryId, StationData, StationId } from './data.model';
+import { DeliveryData, DeliveryId, StationData, StationId, TableColumn } from './data.model';
 import { Store, select } from '@ngrx/store';
 import { StationPropertiesComponent, StationPropertiesData } from './dialog/station-properties/station-properties.component';
 import { DeliveryPropertiesComponent, DeliveryPropertiesData } from './dialog/delivery-properties/delivery-properties.component';
@@ -18,6 +18,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { EditTracingSettingsService } from './services/edit-tracing-settings.service';
 import { EditHighlightingService } from './configuration/edit-highlighting.service';
 import { GraphService } from './graph/graph.service';
+import { TableService } from './services/table.service';
 
 @Injectable()
 export class TracingEffects {
@@ -29,6 +30,7 @@ export class TracingEffects {
         private dialogService: MatDialog,
         private alertService: AlertService,
         private editHighlightingService: EditHighlightingService,
+        private tableService: TableService,
         private store: Store<fromTracing.State>
     ) {}
 
@@ -58,7 +60,8 @@ export class TracingEffects {
                     const dialogData: StationPropertiesData = {
                         station: station,
                         deliveries: deliveries,
-                        connectedStations: connectedStations
+                        connectedStations: connectedStations,
+                        stationColumns: this.tableService.getStationColumns(data)
                     };
 
                     this.dialogService.open(StationPropertiesComponent, { data: dialogData });
@@ -125,7 +128,8 @@ export class TracingEffects {
                             source: data.statMap[delivery.source],
                             target: data.statMap[delivery.target],
                             originalSource: data.statMap[delivery.originalSource],
-                            originalTarget: data.statMap[delivery.originalTarget]
+                            originalTarget: data.statMap[delivery.originalTarget],
+                            deliveryColumns: this.tableService.getDeliveryColumns(data, true)
                         };
 
                         this.dialogService.open(DeliveryPropertiesComponent, { data: dialogData });


### PR DESCRIPTION
Ticket: #421

Changed station and delivery properties dialog:
vip properties and more properties now have the same organization as columns of the filter table and the highlighting options