### PR TITLE
#789 Context Menu "Cross Contamination"

### DIFF
--- a/src/app/tracing/graph/context-menu.service.ts
+++ b/src/app/tracing/graph/context-menu.service.ts
@@ -155,6 +155,7 @@ export class ContextMenuService {
                     action: new ClearTraceMSA()
                 },
                 this.createClearOutbreaksMenuItemData(graphData),
+                this.createClearCrossContaminationsMenuItemData(graphData),
                 this.createClearInvisibilitiesMenuItemData(graphData),
                 this.createCollapseStationsMenuItem(),
                 this.createUncollapseStationsMenuItem(graphData)
@@ -185,6 +186,15 @@ export class ContextMenuService {
                     action: new ClearOutbreaksMSA({ clearStationOutbreaks: true, clearDeliveryOutbreaks: true })
                 }
             ]
+        };
+    }
+
+    private createClearCrossContaminationsMenuItemData(graphdata: GraphServiceData): MenuItemData{
+        const someStationIsCrossContamination = graphdata.stations.some(s => s.crossContamination);
+
+        return{
+            ...MenuItemStrings.clearCrossContaminations,
+            disabled: !someStationIsCrossContamination,
         };
     }
 

--- a/src/app/tracing/graph/context-menu.service.ts
+++ b/src/app/tracing/graph/context-menu.service.ts
@@ -20,7 +20,9 @@ import {
     ShowStationPropertiesMSA,
     ShowElementsTraceMSA,
     MakeElementsInvisibleMSA,
-    ClearOutbreaksMSA} from '../tracing.actions';
+    ClearOutbreaksMSA,
+    ClearCrossContaminationMSA
+} from '../tracing.actions';
 import { CollapseStationsMSA, ExpandStationsMSA, MergeStationsMSA, UncollapseStationsMSA } from '../grouping/grouping.actions';
 import { Action } from '@ngrx/store';
 import { LayoutOption } from './cy-graph/interactive-cy-graph';
@@ -49,7 +51,7 @@ export enum LayoutActionTypes {
 export class LayoutAction implements Action {
     readonly type = LayoutActionTypes.LayoutAction;
 
-    constructor(public payload: { layoutName: LayoutName; nodeIds: string[] }) {}
+    constructor(public payload: { layoutName: LayoutName; nodeIds: string[] }) { }
 }
 
 @Injectable({
@@ -74,7 +76,7 @@ export class ContextMenuService {
         const isContextElementSelected =
             (context.nodeId && graphData.nodeSel[context.nodeId]) ||
             (context.edgeId && graphData.edgeSel[context.edgeId])
-        ;
+            ;
 
         const nodes: CyNodeData[] =
             isContextElementSelected ? graphData.nodeData.filter(n => n.selected) :
@@ -189,12 +191,13 @@ export class ContextMenuService {
         };
     }
 
-    private createClearCrossContaminationsMenuItemData(graphdata: GraphServiceData): MenuItemData{
-        const someStationIsCrossContamination = graphdata.stations.some(s => s.crossContamination);
+    private createClearCrossContaminationsMenuItemData(graphdata: GraphServiceData): MenuItemData {
+        const crossContaminationStationIds = graphdata.stations.filter(s => s.crossContamination).map(s => s.id);
 
-        return{
+        return {
             ...MenuItemStrings.clearCrossContaminations,
-            disabled: !someStationIsCrossContamination,
+            disabled: !crossContaminationStationIds.length ?? crossContaminationStationIds.length > 0,
+            action: new ClearCrossContaminationMSA()
         };
     }
 
@@ -238,22 +241,22 @@ export class ContextMenuService {
             children: [
                 {
                     ...MenuItemStrings.uncollapseSources,
-                    action : new UncollapseStationsMSA({ groupType: GroupType.SOURCE_GROUP }),
+                    action: new UncollapseStationsMSA({ groupType: GroupType.SOURCE_GROUP }),
                     disabled: !isSourceGroupAvailable
                 },
                 {
                     ...MenuItemStrings.uncollapseTargets,
-                    action : new UncollapseStationsMSA({ groupType: GroupType.TARGET_GROUP }),
+                    action: new UncollapseStationsMSA({ groupType: GroupType.TARGET_GROUP }),
                     disabled: !isTargetGroupAvailable
                 },
                 {
                     ...MenuItemStrings.uncollapseSimpleChains,
-                    action : new UncollapseStationsMSA({ groupType: GroupType.SIMPLE_CHAIN }),
+                    action: new UncollapseStationsMSA({ groupType: GroupType.SIMPLE_CHAIN }),
                     disabled: !isSimpleChainAvailable
                 },
                 {
                     ...MenuItemStrings.uncollapseIsolatedClouds,
-                    action : new UncollapseStationsMSA({ groupType: GroupType.ISOLATED_GROUP }),
+                    action: new UncollapseStationsMSA({ groupType: GroupType.ISOLATED_GROUP }),
                     disabled: !isIsolatedGroupAvailable
                 }
             ]
@@ -269,21 +272,21 @@ export class ContextMenuService {
                     children: [
                         {
                             ...MenuItemStrings.collapseSourcesWeightOnly,
-                            action : new CollapseStationsMSA({
+                            action: new CollapseStationsMSA({
                                 groupType: GroupType.SOURCE_GROUP,
                                 groupMode: GroupMode.WEIGHT_ONLY
                             })
                         },
                         {
                             ...MenuItemStrings.collapseSourcesProductAndWeight,
-                            action : new CollapseStationsMSA({
+                            action: new CollapseStationsMSA({
                                 groupType: GroupType.SOURCE_GROUP,
                                 groupMode: GroupMode.PRODUCT_AND_WEIGHT
                             })
                         },
                         {
                             ...MenuItemStrings.collapseSourcesLotAndWeight,
-                            action : new CollapseStationsMSA({
+                            action: new CollapseStationsMSA({
                                 groupType: GroupType.SOURCE_GROUP,
                                 groupMode: GroupMode.LOT_AND_WEIGHT
                             })
@@ -295,21 +298,21 @@ export class ContextMenuService {
                     children: [
                         {
                             ...MenuItemStrings.collapseTargetsWeightOnly,
-                            action : new CollapseStationsMSA({
+                            action: new CollapseStationsMSA({
                                 groupType: GroupType.TARGET_GROUP,
                                 groupMode: GroupMode.WEIGHT_ONLY
                             })
                         },
                         {
                             ...MenuItemStrings.collapseTargetsProductAndWeight,
-                            action : new CollapseStationsMSA({
+                            action: new CollapseStationsMSA({
                                 groupType: GroupType.TARGET_GROUP,
                                 groupMode: GroupMode.PRODUCT_AND_WEIGHT
                             })
                         },
                         {
                             ...MenuItemStrings.collapseTargetsLotAndWeight,
-                            action : new CollapseStationsMSA({
+                            action: new CollapseStationsMSA({
                                 groupType: GroupType.TARGET_GROUP,
                                 groupMode: GroupMode.LOT_AND_WEIGHT
                             })
@@ -318,11 +321,11 @@ export class ContextMenuService {
                 },
                 {
                     ...MenuItemStrings.collapseSimpleChains,
-                    action : new CollapseStationsMSA({ groupType: GroupType.SIMPLE_CHAIN })
+                    action: new CollapseStationsMSA({ groupType: GroupType.SIMPLE_CHAIN })
                 },
                 {
                     ...MenuItemStrings.collapseIsolatedClouds,
-                    action : new CollapseStationsMSA({ groupType: GroupType.ISOLATED_GROUP })
+                    action: new CollapseStationsMSA({ groupType: GroupType.ISOLATED_GROUP })
                 }
             ]
         };
@@ -343,7 +346,7 @@ export class ContextMenuService {
         const allContextDeliveriesAreOutbreaks = graphData.getDelById(contextElements.deliveryIds).every(d => d.outbreak);
         const allContextElementsAreOutbreaks = allContextStationsAreOutbreaks && allContextDeliveriesAreOutbreaks;
         return {
-            ...(allContextElementsAreOutbreaks ? MenuItemStrings.unmarkOutbreaks :MenuItemStrings.markOutbreaks),
+            ...(allContextElementsAreOutbreaks ? MenuItemStrings.unmarkOutbreaks : MenuItemStrings.markOutbreaks),
             action: new MarkElementsAsOutbreakMSA({
                 stationIds: contextElements.stationIds,
                 deliveryIds: contextElements.deliveryIds,
@@ -357,7 +360,7 @@ export class ContextMenuService {
         const allContextDeliveriesHaveKillCon = graphData.getDelById(contextElements.deliveryIds).every(d => d.killContamination);
         const allContextElementsHaveKillCon = allContextStationsHaveKillCon && allContextDeliveriesHaveKillCon;
         return {
-            ...(allContextElementsHaveKillCon ? MenuItemStrings.unsetKillContamination :MenuItemStrings.setKillContamination),
+            ...(allContextElementsHaveKillCon ? MenuItemStrings.unsetKillContamination : MenuItemStrings.setKillContamination),
             action: new SetKillContaminationMSA({
                 stationIds: contextElements.stationIds,
                 deliveryIds: contextElements.deliveryIds,

--- a/src/app/tracing/graph/menu.constants.ts
+++ b/src/app/tracing/graph/menu.constants.ts
@@ -28,6 +28,10 @@ export class MenuItemStrings {
         displayName: 'Clear All Outbreaks'
     };
 
+    static readonly clearCrossContaminations: ItemInfo = {
+        displayName: 'Clear Cross Contaminations'
+    }
+
     static readonly clearInvisibility: ItemInfo = {
         displayName: 'Clear Invisibility'
     };

--- a/src/app/tracing/graph/menu.constants.ts
+++ b/src/app/tracing/graph/menu.constants.ts
@@ -30,7 +30,7 @@ export class MenuItemStrings {
 
     static readonly clearCrossContaminations: ItemInfo = {
         displayName: 'Clear Cross Contaminations'
-    }
+    };
 
     static readonly clearInvisibility: ItemInfo = {
         displayName: 'Clear Invisibility'

--- a/src/app/tracing/services/edit-tracing-settings.service.ts
+++ b/src/app/tracing/services/edit-tracing-settings.service.ts
@@ -66,6 +66,11 @@ export class EditTracingSettingsService {
         };
     }
 
+    getClearCrossContaminationPayload(tracingSettings: TracingSettings): SetTracingSettingsPayload {
+        return this.getSetStationCrossContPayload(tracingSettings, tracingSettings.stations.filter(s => s.crossContamination).map(s => s.id), false)
+    }
+
+
     getSetStationCrossContPayload(tracingSettings: TracingSettings, ids: string[], crossContamination: boolean): SetTracingSettingsPayload {
         const idSet = Utils.createSimpleStringSet(ids);
         return {
@@ -121,7 +126,7 @@ export class EditTracingSettingsService {
         };
     }
 
-    private getNewTracing<T extends(StationTracingSettings | DeliveryTracingSettings)>(
+    private getNewTracing<T extends (StationTracingSettings | DeliveryTracingSettings)>(
         oldTracing: T[], newInvIds: string[]
     ): T[] {
         if (newInvIds.length === 0) {
@@ -135,7 +140,7 @@ export class EditTracingSettingsService {
         }
     }
 
-    resetObservedTypeForElements(tracingSettings: TracingSettings, elements: SelectedElements): TracingSettings | null  {
+    resetObservedTypeForElements(tracingSettings: TracingSettings, elements: SelectedElements): TracingSettings | null {
         if (elements.stations.length > 0 || elements.deliveries.length > 0) {
             return {
                 ...tracingSettings,
@@ -146,7 +151,7 @@ export class EditTracingSettingsService {
         return null;
     }
 
-    private setElementsObservedType<T extends(StationTracingSettings | DeliveryTracingSettings)>(
+    private setElementsObservedType<T extends (StationTracingSettings | DeliveryTracingSettings)>(
         elements: T[],
         ids: string[],
         observedType: ObservedType

--- a/src/app/tracing/services/edit-tracing-settings.service.ts
+++ b/src/app/tracing/services/edit-tracing-settings.service.ts
@@ -67,7 +67,11 @@ export class EditTracingSettingsService {
     }
 
     getClearCrossContaminationPayload(tracingSettings: TracingSettings): SetTracingSettingsPayload {
-        return this.getSetStationCrossContPayload(tracingSettings, tracingSettings.stations.filter(s => s.crossContamination).map(s => s.id), false)
+        return this.getSetStationCrossContPayload(
+            tracingSettings,
+            tracingSettings.stations.filter(s => s.crossContamination).map(s => s.id),
+            false
+        );
     }
 
 
@@ -126,7 +130,7 @@ export class EditTracingSettingsService {
         };
     }
 
-    private getNewTracing<T extends (StationTracingSettings | DeliveryTracingSettings)>(
+    private getNewTracing<T extends(StationTracingSettings | DeliveryTracingSettings)>(
         oldTracing: T[], newInvIds: string[]
     ): T[] {
         if (newInvIds.length === 0) {
@@ -151,7 +155,7 @@ export class EditTracingSettingsService {
         return null;
     }
 
-    private setElementsObservedType<T extends (StationTracingSettings | DeliveryTracingSettings)>(
+    private setElementsObservedType<T extends(StationTracingSettings | DeliveryTracingSettings)>(
         elements: T[],
         ids: string[],
         observedType: ObservedType

--- a/src/app/tracing/tracing.actions.ts
+++ b/src/app/tracing/tracing.actions.ts
@@ -15,6 +15,7 @@ export enum TracingActionTypes {
     MarkElementsAsOutbreakMSA = '[Tracing] Mark Elements as Outbreak',
     SetKillContaminationMSA = '[Tracing] Set Kill Contamination',
     SetStationCrossContaminationMSA = '[Tracing] Set Station Cross Contamination',
+    ClearCrossContaminationMSA = '[Tracing] Clear Cross Contamination',
     MakeElementsInvisibleMSA = '[Tracing] Make Elements Invisible',
     ShowDeliveryPropertiesMSA = '[Tracing] Show Delivery Properties',
     ShowElementsTraceMSA = '[Tracing] Show Elements Trace',
@@ -40,6 +41,10 @@ export class ClearOutbreaksMSA implements Action {
     readonly type = TracingActionTypes.ClearOutbreaksMSA;
 
     constructor(public payload: ClearOutbreaksOptions) {}
+}
+
+export class ClearCrossContaminationMSA implements Action {
+    readonly type = TracingActionTypes.ClearCrossContaminationMSA;
 }
 
 export class ShowStationPropertiesMSA implements Action {

--- a/src/app/tracing/tracing.effects.ts
+++ b/src/app/tracing/tracing.effects.ts
@@ -291,7 +291,7 @@ export class TracingEffects {
                     return of(new tracingStateActions.SetTracingSettingsSOA(payload));
                 }
             } catch (error) {
-                this.alertService.error(`Cross Contaminations could not be cleared!, error: ${error}`)
+                this.alertService.error(`Cross Contaminations could not be cleared!, error: ${error}`);
             }
             return EMPTY;
         })

--- a/src/app/tracing/tracing.effects.ts
+++ b/src/app/tracing/tracing.effects.ts
@@ -281,6 +281,22 @@ export class TracingEffects {
         })
     ));
 
+    clearCrossContaminations$ = createEffect(() => this.actions$.pipe(
+        ofType<tracingEffectActions.ClearCrossContaminationMSA>(tracingEffectActions.TracingActionTypes.ClearCrossContaminationMSA),
+        withLatestFrom(this.store.pipe(select(tracingSelectors.getTracingSettings))),
+        mergeMap(([_action, state]) => {
+            try {
+                const payload = this.editTracSettingsService.getClearCrossContaminationPayload(state);
+                if (payload) {
+                    return of(new tracingStateActions.SetTracingSettingsSOA(payload));
+                }
+            } catch (error) {
+                this.alertService.error(`Cross Contaminations could not be cleared!, error: ${error}`)
+            }
+            return EMPTY;
+        })
+    ));
+
     setSelectedGraphElements$ = createEffect(() => this.actions$.pipe(
         ofType<tracingEffectActions.SetSelectedGraphElementsMSA>(tracingEffectActions.TracingActionTypes.SetSelectedGraphElementsMSA),
         withLatestFrom(this.store.pipe(select(tracingSelectors.selectSharedGraphState))),


### PR DESCRIPTION
Merging this will add an entry for the context menu when clicking on the emty canvas in tracing view, that unsets all Cross Contaminations. 

- [x] Menu Item appears labeled "Clear Cross Contaminations" 
- [x] Menu Item is disabled if there are no Cross Contaminations
- [x] Activating the menu option clears all stations of their cross contamination status