### PR TITLE
Refine display of legend entries.

### DIFF
--- a/src/app/tracing/data.model.ts
+++ b/src/app/tracing/data.model.ts
@@ -186,7 +186,7 @@ export interface GraphSettings {
     fitGraphToVisibleArea: boolean;
     skipUnconnectedStations: boolean;
     selectedElements: SelectedElements;
-    stationPositions: {[key: string]: Position};
+    stationPositions: { [key: string]: Position };
     highlightingSettings: HighlightingSettings;
     schemaLayout: Layout | null;
     gisLayout: Layout | null;
@@ -380,7 +380,7 @@ export interface DataServiceData {
     delSel: Record<DeliveryId, boolean>;
     statVis: Record<StationId, boolean>;
     delVis: Record<DeliveryId, boolean>;
-    legendInfo?: LegendInfo;
+    legendInfo?: LegendDisplayEntry[] | null;
     tracingPropsUpdatedFlag: Record<string, never>;
     stationAndDeliveryHighlightingUpdatedFlag: Record<string, never>;
     highlightingStats?: HighlightingStats;
@@ -512,3 +512,11 @@ export interface Range {
     min: number;
     max: number;
 }
+
+export interface LegendDisplayEntry {
+    name: string;
+    stationColor?: Color | null;
+    deliveryColor?: Color | null;
+    shape?: NodeShapeType | null;
+}
+

--- a/src/app/tracing/data.model.ts
+++ b/src/app/tracing/data.model.ts
@@ -186,7 +186,7 @@ export interface GraphSettings {
     fitGraphToVisibleArea: boolean;
     skipUnconnectedStations: boolean;
     selectedElements: SelectedElements;
-    stationPositions: { [key: string]: Position; };
+    stationPositions: { [key: string]: Position };
     highlightingSettings: HighlightingSettings;
     schemaLayout: Layout | null;
     gisLayout: Layout | null;

--- a/src/app/tracing/data.model.ts
+++ b/src/app/tracing/data.model.ts
@@ -186,7 +186,7 @@ export interface GraphSettings {
     fitGraphToVisibleArea: boolean;
     skipUnconnectedStations: boolean;
     selectedElements: SelectedElements;
-    stationPositions: { [key: string]: Position };
+    stationPositions: { [key: string]: Position; };
     highlightingSettings: HighlightingSettings;
     schemaLayout: Layout | null;
     gisLayout: Layout | null;
@@ -484,25 +484,6 @@ export interface SetInvisibleElementsPayload {
     tracingSettings: TracingSettings;
 }
 
-interface LegendEntry {
-    label: string;
-    color: Color | null;
-    index: number;
-}
-
-interface StationLegendEntry extends LegendEntry {
-    shape: NodeShapeType | null;
-}
-
-export interface DeliveryLegendEntry extends LegendEntry {
-    linePattern: LinePatternType | null;
-}
-
-export interface LegendInfo {
-    stations: StationLegendEntry[];
-    deliveries: DeliveryLegendEntry[];
-}
-
 export interface Size {
     width: number;
     height: number;
@@ -515,8 +496,8 @@ export interface Range {
 
 export interface LegendDisplayEntry {
     name: string;
-    stationColor?: Color | null;
-    deliveryColor?: Color | null;
-    shape?: NodeShapeType | null;
+    stationColor?: Color;
+    deliveryColor?: Color;
+    shape?: NodeShapeType;
 }
 

--- a/src/app/tracing/data.model.ts
+++ b/src/app/tracing/data.model.ts
@@ -487,6 +487,7 @@ export interface SetInvisibleElementsPayload {
 interface LegendEntry {
     label: string;
     color: Color | null;
+    index: number;
 }
 
 interface StationLegendEntry extends LegendEntry {

--- a/src/app/tracing/graph/components/gis-graph/gis-graph.component.ts
+++ b/src/app/tracing/graph/components/gis-graph/gis-graph.component.ts
@@ -1,7 +1,7 @@
 import { Component, ElementRef, OnInit, ViewChild, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
 import html2canvas from 'html2canvas';
-import { GraphType, Layout, LegendInfo, GisGraphState } from '../../../data.model';
+import { GraphType, Layout, GisGraphState, LegendDisplayEntry } from '../../../data.model';
 import * as _ from 'lodash';
 import { Action, Store } from '@ngrx/store';
 import { ContextMenuRequestInfo, GraphServiceData } from '../../graph.model';
@@ -51,7 +51,7 @@ export class GisGraphComponent implements OnInit, OnDestroy {
     private sharedGraphData: GraphServiceData | null = null;
     private graphData_: GraphData | null = null;
     private unknownLatLonRect_: BoundaryRect | null = null;
-    private legendInfo_: LegendInfo | null = null;
+    private legendInfo_: LegendDisplayEntry[] | null = null;
     private cyConfig_: CyConfig = {
         minZoom: GisGraphComponent.MIN_ZOOM,
         maxZoom: GisGraphComponent.MAX_ZOOM,
@@ -66,7 +66,7 @@ export class GisGraphComponent implements OnInit, OnDestroy {
         private gisPositioningService: GisPositioningService,
         private contextMenuService: ContextMenuService,
         private alertService: AlertService
-    ) {}
+    ) { }
 
     ngOnInit() {
 
@@ -131,7 +131,7 @@ export class GisGraphComponent implements OnInit, OnDestroy {
         return this.graphData_;
     }
 
-    get legendInfo(): LegendInfo | null {
+    get legendInfo(): LegendDisplayEntry[] | null {
         return this.legendInfo_;
     }
 

--- a/src/app/tracing/graph/components/graph-legend-view/graph-legend-view.component.ts
+++ b/src/app/tracing/graph/components/graph-legend-view/graph-legend-view.component.ts
@@ -1,10 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { LegendDisplayEntry } from '@app/tracing/data.model';
 
-interface LegendDisplayEntryWithIndex extends LegendDisplayEntry {
-    index: number;
-}
-
 @Component({
     selector: 'fcl-graph-legend-view',
     templateUrl: './graph-legend-view.component.html',
@@ -41,11 +37,9 @@ export class GraphLegendViewComponent {
 
 
     private updateLegend(legend: LegendDisplayEntry[]) {
-        if (!legend) { return; }
         this.legend = legend;
         this.showStationColumn_ = this.legend.some(e => !!e.shape || !!e.stationColor);
         this.showDeliveryColumn_ = this.legend.some(e => !!e.deliveryColor);
-
     }
 
 }

--- a/src/app/tracing/graph/components/graph-legend-view/graph-legend-view.component.ts
+++ b/src/app/tracing/graph/components/graph-legend-view/graph-legend-view.component.ts
@@ -44,6 +44,8 @@ export class GraphLegendViewComponent {
         // Early Return if no legendinfo
         if (!legend) { return; }
 
+        console.log("legend", legend);
+
         this.legend = legend;
         this.showStationColumn_ = this.legend.some(e => !!e.shape || !!e.stationColor);
         this.showDeliveryColumn_ = this.legend.some(e => !!e.deliveryColor);

--- a/src/app/tracing/graph/components/graph-legend-view/graph-legend-view.component.ts
+++ b/src/app/tracing/graph/components/graph-legend-view/graph-legend-view.component.ts
@@ -41,11 +41,7 @@ export class GraphLegendViewComponent {
 
 
     private updateLegend(legend: LegendDisplayEntry[]) {
-        // Early Return if no legendinfo
         if (!legend) { return; }
-
-        console.log("legend", legend);
-
         this.legend = legend;
         this.showStationColumn_ = this.legend.some(e => !!e.shape || !!e.stationColor);
         this.showDeliveryColumn_ = this.legend.some(e => !!e.deliveryColor);

--- a/src/app/tracing/graph/components/graph-legend-view/graph-legend-view.component.ts
+++ b/src/app/tracing/graph/components/graph-legend-view/graph-legend-view.component.ts
@@ -1,12 +1,6 @@
 import { Component, Input } from '@angular/core';
-import { LegendInfo, Color, NodeShapeType } from '@app/tracing/data.model';
+import { LegendDisplayEntry } from '@app/tracing/data.model';
 
-interface LegendDisplayEntry {
-    name: string;
-    stationColor?: Color;
-    deliveryColor?: Color;
-    shape?: NodeShapeType;
-}
 interface LegendDisplayEntryWithIndex extends LegendDisplayEntry {
     index: number;
 }
@@ -18,13 +12,13 @@ interface LegendDisplayEntryWithIndex extends LegendDisplayEntry {
 })
 export class GraphLegendViewComponent {
 
-    private legendInfo_: LegendInfo | null = null;
+    private legendInfo_: LegendDisplayEntry[] | null = null;
     private showStationColumn_ = false;
     private showDeliveryColumn_ = false;
 
     @Input() showMissingGisInfoEntry: boolean;
 
-    @Input() set legendInfo(legendInfo: LegendInfo) {
+    @Input() set legendInfo(legendInfo: LegendDisplayEntry[]) {
         if (this.legendInfo_ !== legendInfo) {
             this.updateLegend(legendInfo);
             this.legendInfo_ = legendInfo;
@@ -46,63 +40,11 @@ export class GraphLegendViewComponent {
     }
 
 
-    private updateLegend(legendInfo: LegendInfo) {
+    private updateLegend(legend: LegendDisplayEntry[]) {
         // Early Return if no legendinfo
-        if (!legendInfo) { return; }
+        if (!legend) { return; }
 
-        this.legend = legendInfo.stations.map(
-            (stationEntry): LegendDisplayEntryWithIndex =>
-                ({
-                    name: stationEntry.label,
-                    index: stationEntry.index,
-                    stationColor: stationEntry.color ?? undefined,
-                    shape: stationEntry.shape ?? undefined,
-                    deliveryColor: undefined
-                })
-        )
-            .concat(
-                legendInfo.deliveries
-                    .map(
-                        (deliveryEntry): LegendDisplayEntryWithIndex => ({
-                            name: deliveryEntry.label,
-                            index: deliveryEntry.index,
-                            stationColor: undefined,
-                            shape: undefined,
-                            deliveryColor: deliveryEntry.color ?? undefined
-                        })
-                    )
-            )
-            //Should use toSorted once we update to a newer TS version.
-            .sort(
-                ((entryA, entryB) => entryA.index - entryB.index)
-            )
-            .reduce(
-                (legend: LegendDisplayEntry[], currentEntry: LegendDisplayEntryWithIndex) => {
-                    const index = legend.findIndex((entry) => entry.name === currentEntry.name);
-                    if (index >= 0) {
-                        //Should use legend.with(index,{newObj}) once we update to a newer TS version.
-                        const newArray = legend;
-                        newArray[index] = {
-                            name: currentEntry.name,
-                            stationColor: legend[index]?.stationColor ?? currentEntry?.stationColor,
-                            deliveryColor: legend[index]?.deliveryColor ?? currentEntry?.deliveryColor,
-                            shape: legend[index]?.shape ?? currentEntry?.shape
-                        };
-                        return newArray;
-                    } else {
-                        return [...legend,
-                            {
-                                name: currentEntry.name,
-                                stationColor: legend[index]?.stationColor ?? currentEntry?.stationColor,
-                                deliveryColor: legend[index]?.deliveryColor ?? currentEntry?.deliveryColor,
-                                shape: legend[index]?.shape ?? currentEntry?.shape
-                            }
-                        ];
-                    }
-                },
-                []
-            );
-
+        this.legend = legend;
         this.showStationColumn_ = this.legend.some(e => !!e.shape || !!e.stationColor);
         this.showDeliveryColumn_ = this.legend.some(e => !!e.deliveryColor);
 

--- a/src/app/tracing/graph/components/schema-graph/schema-graph.component.ts
+++ b/src/app/tracing/graph/components/schema-graph/schema-graph.component.ts
@@ -1,7 +1,7 @@
 import { Component, ElementRef, OnInit, ViewChild, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
 import html2canvas from 'html2canvas';
-import { GraphType, LegendInfo, SchemaGraphState } from '../../../data.model';
+import { GraphType, LegendDisplayEntry, SchemaGraphState } from '../../../data.model';
 import * as _ from 'lodash';
 import { Action, Store } from '@ngrx/store';
 import { ContextMenuRequestInfo, GraphServiceData } from '../../graph.model';
@@ -50,7 +50,7 @@ export class SchemaGraphComponent implements OnInit, OnDestroy {
     private cachedState: SchemaGraphState | null = null;
     private sharedGraphData: GraphServiceData | null = null;
     private schemaGraphData: GraphData | null = null;
-    private legendInfo_: LegendInfo | null = null;
+    private legendInfo_: LegendDisplayEntry[] | null = null;
     private cyConfig_: CyConfig = {
         minZoom: SchemaGraphComponent.MIN_ZOOM,
         maxZoom: SchemaGraphComponent.MAX_ZOOM
@@ -67,7 +67,7 @@ export class SchemaGraphComponent implements OnInit, OnDestroy {
         private schemaGraphService: SchemaGraphService,
         private contextMenuService: ContextMenuService,
         private alertService: AlertService
-    ) {}
+    ) { }
 
     ngOnInit() {
 
@@ -166,7 +166,7 @@ export class SchemaGraphComponent implements OnInit, OnDestroy {
         return this.schemaGraphData;
     }
 
-    get legendInfo(): LegendInfo | null {
+    get legendInfo(): LegendDisplayEntry[] | null {
         return this.legendInfo_;
     }
 

--- a/src/app/tracing/services/highlighting.service.ts
+++ b/src/app/tracing/services/highlighting.service.ts
@@ -181,24 +181,19 @@ export class HighlightingService {
         return {
             name: rule.name,
             deliveryColor: this.mapToColor(rule.color),
-            stationColor: undefined,
-            shape: undefined
-
         };
     }
 
     private stationRuleToDisplayEntry(rule: StationHighlightingRule): LegendDisplayEntry {
         return {
             name: rule.name,
-            deliveryColor: undefined,
             stationColor: this.mapToColor(rule.color),
             shape: rule.shape ?? undefined
-
         };
     }
 
     private getLegendInfo(
-        activeHighlightings: { stations: Record<RuleId, boolean>; deliveries: Record<RuleId, boolean> }
+        activeHighlightings: { stations: Record<RuleId, boolean>; deliveries: Record<RuleId, boolean>; }
     ): LegendDisplayEntry[] {
 
         const stationRulesToDisplay = this.enabledStatHRules.filter(rule =>
@@ -217,14 +212,14 @@ export class HighlightingService {
 
         const uniqueDisplayEntries: LegendDisplayEntry[] = [];
         allDisplayEntries.forEach((entry) => {
-            const index = uniqueDisplayEntries.findIndex((entry) => entry.name === entry.name);
+            const index = uniqueDisplayEntries.findIndex((toCompare) => entry.name === toCompare.name);
             if (index >= 0) {
                 uniqueDisplayEntries[index] = {
-                    ...uniqueDisplayEntries[index],
-                    ...entry
+                    ...entry,
+                    ...uniqueDisplayEntries[index]
                 };
             } else {
-                return uniqueDisplayEntries.push(entry);
+                uniqueDisplayEntries.push(entry);
             }
         });
 
@@ -265,7 +260,7 @@ export class HighlightingService {
 
     private getActiveHighlightingRules<
         T extends StationOrDeliveryData,
-        K extends(T extends StationData ? StationHighlightingRule : DeliveryHighlightingRule)
+        K extends (T extends StationData ? StationHighlightingRule : DeliveryHighlightingRule)
     >(fclElement: T, highlightingRules: K[]): K[] {
         return highlightingRules.filter(rule =>
             !rule.invisible &&
@@ -403,11 +398,11 @@ export class HighlightingService {
 
     private getCommonHighlightingInfo<
         T extends StationData | DeliveryData,
-        K extends(T extends StationData ? StationHighlightingRule : DeliveryHighlightingRule)
+        K extends (T extends StationData ? StationHighlightingRule : DeliveryHighlightingRule)
     >(
         fclElement: T,
         highlightingRules: K[]
-    ): { label: string; color: number[][] } {
+    ): { label: string; color: number[][]; } {
 
         const labelParts: string[] = [];
         for (const rule of highlightingRules) {

--- a/src/app/tracing/services/highlighting.service.ts
+++ b/src/app/tracing/services/highlighting.service.ts
@@ -180,7 +180,7 @@ export class HighlightingService {
     private deliveryRuleToDisplayEntry(rule: DeliveryHighlightingRule): LegendDisplayEntry {
         return {
             name: rule.name,
-            deliveryColor: this.mapToColor(rule.color),
+            deliveryColor: this.mapToColor(rule.color)
         };
     }
 
@@ -193,7 +193,7 @@ export class HighlightingService {
     }
 
     private getLegendInfo(
-        activeHighlightings: { stations: Record<RuleId, boolean>; deliveries: Record<RuleId, boolean>; }
+        activeHighlightings: { stations: Record<RuleId, boolean>; deliveries: Record<RuleId, boolean> }
     ): LegendDisplayEntry[] {
 
         const stationRulesToDisplay = this.enabledStatHRules.filter(rule =>
@@ -260,7 +260,7 @@ export class HighlightingService {
 
     private getActiveHighlightingRules<
         T extends StationOrDeliveryData,
-        K extends (T extends StationData ? StationHighlightingRule : DeliveryHighlightingRule)
+        K extends(T extends StationData ? StationHighlightingRule : DeliveryHighlightingRule)
     >(fclElement: T, highlightingRules: K[]): K[] {
         return highlightingRules.filter(rule =>
             !rule.invisible &&
@@ -398,11 +398,11 @@ export class HighlightingService {
 
     private getCommonHighlightingInfo<
         T extends StationData | DeliveryData,
-        K extends (T extends StationData ? StationHighlightingRule : DeliveryHighlightingRule)
+        K extends(T extends StationData ? StationHighlightingRule : DeliveryHighlightingRule)
     >(
         fclElement: T,
         highlightingRules: K[]
-    ): { label: string; color: number[][]; } {
+    ): { label: string; color: number[][] } {
 
         const labelParts: string[] = [];
         for (const rule of highlightingRules) {

--- a/src/app/tracing/services/highlighting.service.ts
+++ b/src/app/tracing/services/highlighting.service.ts
@@ -208,33 +208,31 @@ export class HighlightingService {
         const deliveryRulesToDisplay = this.enabledDelHRules.filter(rule =>
             rule.showInLegend && (activeHighlightings.deliveries[rule.id])
         );
-        return this.statHighlightingRules
+
+        const allDisplayEntries = this.statHighlightingRules
             .map(rule => this.stationRuleToDisplayEntry(rule))
             .concat(this.delHighlightingRules
                 .map(rule => this.deliveryRuleToDisplayEntry(rule))
-            )
-            .reduce(
-                (acc: LegendDisplayEntry[], current) => {
-                    const index = acc.findIndex((entry) => entry.name === current.name);
-                    if (index >= 0) {
-                        //Should use legend.with(index,{newObj}) once we update to a newer TS version.
-                        const newArray = acc;
-                        newArray[index] = {
-                            ...acc[index],
-                            ...current
-                        };
-                        return newArray;
-                    } else {
-                        return [...acc, current];
-                    }
-                },
-                []
-            )
-            .map(rule => stationRulesToDisplay.some(enabledRule => enabledRule.name === rule.name)
-                ? rule
-                : { ...rule, stationColor: undefined, shape: undefined }
+            );
 
-            )
+        const uniqueDisplayEntries: LegendDisplayEntry[] = [];
+        allDisplayEntries.forEach((entry) => {
+            const index = uniqueDisplayEntries.findIndex((entry) => entry.name === entry.name);
+            if (index >= 0) {
+                uniqueDisplayEntries[index] = {
+                    ...uniqueDisplayEntries[index],
+                    ...entry
+                };
+            } else {
+                return uniqueDisplayEntries.push(entry);
+            }
+        });
+
+        return uniqueDisplayEntries.map(rule => stationRulesToDisplay.some(enabledRule => enabledRule.name === rule.name)
+            ? rule
+            : { ...rule, stationColor: undefined, shape: undefined }
+
+        )
             .map(rule => deliveryRulesToDisplay.some(enabledRule => enabledRule.name === rule.name)
                 ? rule
                 : { ...rule, deliveryColor: undefined }

--- a/src/app/tracing/services/highlighting.service.ts
+++ b/src/app/tracing/services/highlighting.service.ts
@@ -158,7 +158,7 @@ export class HighlightingService {
 
         data.isStationAnonymizationActive = this.anonymizeStationsIfApplicable(data.stations, this.enabledStatHRules, effElementsStats);
 
-        data.legendInfo = this.getLegendInfo(state, {
+        data.legendInfo = this.getLegendInfo({
             stations: this.getRuleIdToIsActiveMap(
                 this.enabledStatHRules,
                 effElementsStats
@@ -178,36 +178,35 @@ export class HighlightingService {
     }
 
     private getLegendInfo(
-        state: DataServiceInputState,
-        activeHighlightings: { stations: Record<RuleId, boolean>; deliveries: Record<RuleId, boolean>}
+        activeHighlightings: { stations: Record<RuleId, boolean>; deliveries: Record<RuleId, boolean> }
     ): LegendInfo {
-
-        const ruleIdToIsCommonLinkRuleMap: Record<RuleId, boolean> = {};
-        this.getCommonLinkEntries(state).forEach(
-            commonLinkRule => ruleIdToIsCommonLinkRuleMap[commonLinkRule.id] = true
-        );
-
         return {
             stations: this.enabledStatHRules.filter(rule =>
                 rule.showInLegend &&
-                (activeHighlightings.stations[rule.id] || ruleIdToIsCommonLinkRuleMap[rule.id])
-            ).map(rule =>
-                ({ label: rule.name, color: this.mapToColor(rule.color), shape: rule.shape })
+                (activeHighlightings.stations[rule.id] || this.isCommonLinkRule(rule))
+            ).map((rule) =>
+                ({
+                    label: rule.name,
+                    color: this.mapToColor(rule.color),
+                    shape: rule.shape,
+                    index: this.statHighlightingRules.findIndex(comp => comp.id === rule.id)
+                })
             ),
             deliveries: this.enabledDelHRules.filter(rule =>
                 rule.showInLegend && (activeHighlightings.deliveries[rule.id])
             ).map(rule =>
-                ({ label: rule.name, color: this.mapToColor(rule.color), linePattern: rule.linePattern })
+                ({
+                    label: rule.name,
+                    color: this.mapToColor(rule.color),
+                    linePattern: rule.linePattern,
+                    index: this.delHighlightingRules.findIndex(comp => comp.id === rule.id)
+                })
             )
         };
     }
 
     private mapToColor(color: number[] | null): Color | null {
         return (color && color.length === 3) ? { r: color[0], g: color[1], b: color[2] } : null;
-    }
-
-    private getCommonLinkEntries(state: DataServiceInputState): StationHighlightingRule[] {
-        return this.enabledStatHRules.filter(rule => this.isCommonLinkRule(rule));
     }
 
     private isCommonLinkRule(rule: HighlightingRule): boolean {

--- a/src/app/tracing/services/highlighting.service.ts
+++ b/src/app/tracing/services/highlighting.service.ts
@@ -198,7 +198,7 @@ export class HighlightingService {
     }
 
     private getLegendInfo(
-        activeHighlightings: { stations: Record<RuleId, boolean>; deliveries: Record<RuleId, boolean>; }
+        activeHighlightings: { stations: Record<RuleId, boolean>; deliveries: Record<RuleId, boolean> }
     ): LegendDisplayEntry[] {
 
         const stationRulesToDisplay = this.enabledStatHRules.filter(rule =>
@@ -208,8 +208,6 @@ export class HighlightingService {
         const deliveryRulesToDisplay = this.enabledDelHRules.filter(rule =>
             rule.showInLegend && (activeHighlightings.deliveries[rule.id])
         );
-        console.log("stations", this.statHighlightingRules);
-        console.log("deliveries", this.delHighlightingRules);
         return this.statHighlightingRules
             .map(rule => this.stationRuleToDisplayEntry(rule))
             .concat(this.delHighlightingRules
@@ -269,7 +267,7 @@ export class HighlightingService {
 
     private getActiveHighlightingRules<
         T extends StationOrDeliveryData,
-        K extends (T extends StationData ? StationHighlightingRule : DeliveryHighlightingRule)
+        K extends(T extends StationData ? StationHighlightingRule : DeliveryHighlightingRule)
     >(fclElement: T, highlightingRules: K[]): K[] {
         return highlightingRules.filter(rule =>
             !rule.invisible &&
@@ -407,11 +405,11 @@ export class HighlightingService {
 
     private getCommonHighlightingInfo<
         T extends StationData | DeliveryData,
-        K extends (T extends StationData ? StationHighlightingRule : DeliveryHighlightingRule)
+        K extends(T extends StationData ? StationHighlightingRule : DeliveryHighlightingRule)
     >(
         fclElement: T,
         highlightingRules: K[]
-    ): { label: string; color: number[][]; } {
+    ): { label: string; color: number[][] } {
 
         const labelParts: string[] = [];
         for (const rule of highlightingRules) {


### PR DESCRIPTION
Merging this commit will change the behaviour of the legend to be sorted by the index as the rules appear in the highliting rules table.
For rules that have both a Station and a Delivery rule, the lower of the two indecies is used.
Jumping can now only occur if a user deliberately sorts the delivery and station highliting rules differently.

Additionally the graphviewcomponent and highliting service functions that needed to be ajusted for this change where refactored.

Ticket: #785