### PR TITLE
Hide deliveries to invisible stations in station property diaglog.

### DIFF
--- a/src/app/tracing/dialog/station-properties/station-properties.component.ts
+++ b/src/app/tracing/dialog/station-properties/station-properties.component.ts
@@ -324,9 +324,7 @@ export class StationPropertiesComponent implements OnInit, OnDestroy {
 
     private shouldDeliveryBeVisible(deliveryId: DeliveryId): boolean {
         const delivery = this.data.deliveries.get(deliveryId)!;
-        const otherStation = this.data.connectedStations.get(delivery.source !== this.data.station.id ? delivery.source : delivery.target)!;
-
-        return !otherStation.invisible;
+        return !delivery.invisible;
     }
 
     private createDeliveryNode(deliveryId: DeliveryId): NodeDatum {
@@ -420,7 +418,7 @@ export class StationPropertiesComponent implements OnInit, OnDestroy {
         const deliveriesByLotKey: Map<LotKey, DeliveryId[]> = new Map();
 
         this.data.deliveries.forEach(delivery => {
-            if (this.shouldDeliveryBeVisible(delivery.id)) {
+            if (!delivery.invisible) {
                 const lotKey = this.getInternalLotKey(delivery);
 
                 if (deliveriesByLotKey.has(lotKey)) {

--- a/src/app/tracing/dialog/station-properties/station-properties.component.ts
+++ b/src/app/tracing/dialog/station-properties/station-properties.component.ts
@@ -187,9 +187,8 @@ export class StationPropertiesComponent implements OnInit, OnDestroy {
             } else {
                 this.initDeliveryBasedData();
             }
-            console.log('preOptimize', this.nodeInData, this.nodeOutData, this.edgeData);
-            const optimizer = new DataOptimizer(this.nodeInData, this.nodeOutData, this.edgeData);
 
+            const optimizer = new DataOptimizer(this.nodeInData, this.nodeOutData, this.edgeData);
             optimizer.optimize();
 
             let yIn = 1 + StationPropertiesComponent.DELIVERIES_HEADER_HEIGHT + StationPropertiesComponent.NODE_PADDING;
@@ -415,8 +414,6 @@ export class StationPropertiesComponent implements OnInit, OnDestroy {
                 target: nodeOutMap.get(connection.target)!
             });
         }
-        console.log('DeliveryBased, nodeIn', this.nodeInData);
-        console.log('DeliveryBased, nodeOut', this.nodeOutData);
     }
 
     private initLotBasedData(ingredientsByLotKey: Map<LotKey, Set<DeliveryId>>) {
@@ -477,8 +474,6 @@ export class StationPropertiesComponent implements OnInit, OnDestroy {
         );
 
         this.nodeOutData = Array.from(nodeOutMap.values());
-        console.log('LotBased, nodeIn', this.nodeInData);
-        console.log('LotBased, nodeOut', this.nodeOutData);
     }
 
     private addNodesHeader(): void {

--- a/src/app/tracing/util/constants.ts
+++ b/src/app/tracing/util/constants.ts
@@ -16,7 +16,7 @@ export class Constants {
     static readonly EXAMPLE_DATA_FILE_STRUCTURE: ExampleData[] = [
         {
             name: 'Example Data',
-            path:  Constants.EXAMPLE_DATA_BASE_DIR + 'ExampleData.json'
+            path: Constants.EXAMPLE_DATA_BASE_DIR + 'ExampleData.json'
         },
         {
             name: 'Babytea',
@@ -24,15 +24,15 @@ export class Constants {
             children: [
                 {
                     name: 'Scenario 1',
-                    path:  Constants.EXAMPLE_DATA_BASE_DIR + Constants.EXAMPLE_DATA_SUB_DIR_1 + 'Scenario_1_Outbreak-Baby-Tea.json'
+                    path: Constants.EXAMPLE_DATA_BASE_DIR + Constants.EXAMPLE_DATA_SUB_DIR_1 + 'Scenario_1_Outbreak-Baby-Tea.json'
                 },
                 {
                     name: 'Scenario 2',
-                    path:  Constants.EXAMPLE_DATA_BASE_DIR + Constants.EXAMPLE_DATA_SUB_DIR_1 + 'Scenario_2_LaSource.json'
+                    path: Constants.EXAMPLE_DATA_BASE_DIR + Constants.EXAMPLE_DATA_SUB_DIR_1 + 'Scenario_2_LaSource.json'
                 },
                 {
                     name: 'Scenario 3',
-                    path:  Constants.EXAMPLE_DATA_BASE_DIR + Constants.EXAMPLE_DATA_SUB_DIR_1 + 'Scenario_3_All-Stations.json'
+                    path: Constants.EXAMPLE_DATA_BASE_DIR + Constants.EXAMPLE_DATA_SUB_DIR_1 + 'Scenario_3_All-Stations.json'
                 }
             ]
         }
@@ -149,7 +149,7 @@ export class Constants {
     static readonly NODE_SIZE_TO_EDGE_WIDTH_MAP = Map<number, number>(
         Constants.NODE_SIZES.toArray().map(nodeSize => [
             nodeSize,
-            Number((nodeSize/Constants.NODE_SIZE_TO_EDGE_WIDTH_FACTOR).toPrecision(1)) // edgeWidth
+            Number((nodeSize / Constants.NODE_SIZE_TO_EDGE_WIDTH_FACTOR).toPrecision(1)) // edgeWidth
         ])
     );
 
@@ -227,4 +227,14 @@ export class Constants {
     );
 
     static readonly DELIVERYTABLE_LOTKEYCOLUMN = 'Product_k';
+
+    static readonly COLOR_BLACK: Color = { r: 0, g: 0, b: 0 };
+    static readonly COLOR_WHITE: Color = { r: 255, g: 255, b: 255 };
+
+
+    static readonly DEFAULT_FILL_COLOR = this.COLOR_WHITE;
+    static readonly DEFAULT_STROKE_COLOR = this.COLOR_BLACK;
+    static readonly HOVER_FILL_COLOR: Color = { r: 128, g: 128, b: 255 };
+    static readonly HOVER_STROKE_COLOR: Color = { r: 0, g: 0, b: 255 };
+    static readonly INVISIBLE_STROKE_COLOR: Color = { r: 211, g: 211, b: 211 };
 }


### PR DESCRIPTION
Merging this will cause deliveries to and from invisible station not to be shown in the properties tab of connected stations.

We should consider refactoring the station-properties-component to use more locally scoped variables and function return values, and reduce mutation of class variables to a minimum. Additionally the heavy use of the non-null-assertion operator should perhaps be reconsidered.

Ticket: Station property dialog shows hidden deliveries #417