### PR TITLE
Refactor Color to be an object rather than an array.

### DIFF
--- a/src/app/tracing/configuration/rule-conversion.ts
+++ b/src/app/tracing/configuration/rule-conversion.ts
@@ -82,7 +82,7 @@ function convertInvEditRuleToDeliveryHRule(editRule: InvEditRule): DeliveryHighl
 function convertCSEditRuleToStatHRule(editRule: ColorAndShapeEditRule): StationHighlightingRule {
     return {
         ...convertEditRuleToHRule(editRule),
-        color: editRule.color === null ? null : Utils.colorToRGBArray(editRule.color),
+        color: editRule.color,
         shape: editRule.shape,
         showInLegend: editRule.showInLegend
     };
@@ -91,7 +91,7 @@ function convertCSEditRuleToStatHRule(editRule: ColorAndShapeEditRule): StationH
 function convertColorEditRuleToDeliveryHRule(editRule: ColorEditRule): DeliveryHighlightingRule {
     return {
         ...convertEditRuleToHRule(editRule),
-        color: Utils.colorToRGBArray(editRule.color),
+        color: editRule.color,
         showInLegend: editRule.showInLegend,
         linePattern: null
     };
@@ -137,7 +137,7 @@ export function convertStatHRuleToCSEditRule(rule: StationHighlightingRule): Col
     return {
         ...convertHRuleToEditRuleCore(rule),
         type: RuleType.COLOR_AND_SHAPE,
-        color: rule.color === null ? null : Utils.rgbArrayToColor(rule.color),
+        color: rule.color,
         shape: rule.shape,
         showInLegend: rule.showInLegend
     };
@@ -147,7 +147,7 @@ export function convertDeliveryHRuleToColorEditRule(rule: DeliveryHighlightingRu
     return {
         ...convertHRuleToEditRuleCore(rule),
         type: RuleType.COLOR,
-        color: Utils.rgbArrayToColor(rule.color!),
+        color: rule.color!,
         showInLegend: rule.showInLegend
     };
 }
@@ -230,7 +230,7 @@ function convertHRuleToRuleListItem(rule: HighlightingRule, stats: HighlightingS
     return {
         id: rule.id,
         name: rule.name,
-        color: rule.color === null ? null : Utils.rgbArrayToColor(rule.color),
+        color: rule.color,
         shape: null,
         showInLegend: rule.showInLegend,
         autoDisabled: rule.autoDisabled,

--- a/src/app/tracing/data.model.ts
+++ b/src/app/tracing/data.model.ts
@@ -40,7 +40,7 @@ export interface TableColumn {
 export type Property = TableColumn;
 
 export interface RowHighlightingInfo {
-    color: number[][];
+    color: Color[];
     shape?: NodeShapeType | null;
 }
 
@@ -225,7 +225,7 @@ export interface HighlightingRule {
     id: HighlightingRuleId;
     name: string;
     showInLegend: boolean;
-    color: number[] | null;
+    color: Color | null;
     invisible: boolean;
     userDisabled: boolean;
     autoDisabled: boolean;
@@ -410,7 +410,7 @@ export interface StationData extends StationStoreData, StationTracingData, ViewD
 
 export interface HighlightingInfo {
     label: string;
-    color: number[][];
+    color: Color[];
 }
 
 export interface StationHighlightingInfo extends HighlightingInfo {

--- a/src/app/tracing/dialog/deliveries-properties/deliveries-properties.component.ts
+++ b/src/app/tracing/dialog/deliveries-properties/deliveries-properties.component.ts
@@ -9,7 +9,7 @@ import * as fromTracing from '../../state/tracing.reducers';
 import * as tracingSelectors from '../../state/tracing.selectors';
 import { AlertService } from '@app/shared/services/alert.service';
 import { SetSelectedElementsSOA } from '@app/tracing/state/tracing.actions';
-import { DataServiceInputState, TableRow } from '@app/tracing/data.model';
+import { Color, DataServiceInputState, TableRow } from '@app/tracing/data.model';
 
 interface DeliveriesPropertiesData {
     deliveryIds: string[];
@@ -29,7 +29,7 @@ interface Filter {
     filterProps: string[];
 }
 
-interface FilterColumn extends Column, Filter {}
+interface FilterColumn extends Column, Filter { }
 
 @Component({
     selector: 'fcl-deliveries-properties',
@@ -140,18 +140,18 @@ export class DeliveriesPropertiesComponent implements OnDestroy {
     private setRowColors() {
         this._unfilteredRows.forEach(
             row => {
-                const colors = row.highlightingInfo.color.length === 0 ? [[0, 0, 0]] : row.highlightingInfo.color;
+                const colors = row.highlightingInfo.color.length === 0 ? [{ r: 0, b: 0, g: 0 }] : row.highlightingInfo.color;
 
                 row.hColor = `${this.colorToBackgroundString(colors)}`;
             }
         );
     }
 
-    private colorToCss(color: number[]): string {
-        return `rgb(${color[0]},${color[1]},${color[2]})`;
+    private colorToCss(color: Color): string {
+        return `rgb(${color.r},${color.b},${color.g})`;
     }
 
-    private colorToBackgroundString(colors: number[][]): string {
+    private colorToBackgroundString(colors: Color[]): string {
         const nColors = colors.length;
         if (nColors === 1) {
             return this.colorToCss(colors[0]);
@@ -260,7 +260,7 @@ export class DeliveriesPropertiesComponent implements OnDestroy {
             }
             return (
                 (typeof values[0] === 'string') ?
-                values as string[] :
+                    values as string[] :
                     values.map(x => x.toString())
             );
         } else {

--- a/src/app/tracing/dialog/deliveries-properties/deliveries-properties.component.ts
+++ b/src/app/tracing/dialog/deliveries-properties/deliveries-properties.component.ts
@@ -147,17 +147,13 @@ export class DeliveriesPropertiesComponent implements OnDestroy {
         );
     }
 
-    private colorToCss(color: Color): string {
-        return `rgb(${color.r},${color.g},${color.b})`;
-    }
-
     private colorToBackgroundString(colors: Color[]): string {
         const nColors = colors.length;
         if (nColors === 1) {
-            return this.colorToCss(colors[0]);
+            return Utils.colorToCss(colors[0]);
         } else {
             return 'linear-gradient(to right, ' + colors
-                .map(color => this.colorToCss(color))
+                .map(color => Utils.colorToCss(color))
                 .map((cssColor, index) => `${cssColor} ${index / nColors * 100}%, ${cssColor} ${(index + 1) / nColors * 100}%`)
                 .join(', ')
                 + ')';

--- a/src/app/tracing/dialog/deliveries-properties/deliveries-properties.component.ts
+++ b/src/app/tracing/dialog/deliveries-properties/deliveries-properties.component.ts
@@ -140,7 +140,7 @@ export class DeliveriesPropertiesComponent implements OnDestroy {
     private setRowColors() {
         this._unfilteredRows.forEach(
             row => {
-                const colors = row.highlightingInfo.color.length === 0 ? [{ r: 0, b: 0, g: 0 }] : row.highlightingInfo.color;
+                const colors = row.highlightingInfo.color.length === 0 ? [{ r: 0, g: 0, b: 0 }] : row.highlightingInfo.color;
 
                 row.hColor = `${this.colorToBackgroundString(colors)}`;
             }
@@ -148,7 +148,7 @@ export class DeliveriesPropertiesComponent implements OnDestroy {
     }
 
     private colorToCss(color: Color): string {
-        return `rgb(${color.r},${color.b},${color.g})`;
+        return `rgb(${color.r},${color.g},${color.b})`;
     }
 
     private colorToBackgroundString(colors: Color[]): string {

--- a/src/app/tracing/graph/graph.service.ts
+++ b/src/app/tracing/graph/graph.service.ts
@@ -488,7 +488,7 @@ export class GraphService {
             edgeColors = concat([[GraphService.DEFAULT_EDGE_COLOR]], edgeColors);
         }
         return _.uniqWith(concat(...edgeColors),
-            (c1: Color, c2: Color) => c1.r === c2.r && c1.b === c2.b && c1.g === c2.g
+            (c1: Color, c2: Color) => c1.r === c2.r && c1.g === c2.g && c1.b === c2.b
         );
     }
 

--- a/src/app/tracing/graph/graph.service.ts
+++ b/src/app/tracing/graph/graph.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
 import {
     DeliveryData, DataServiceData, NodeShapeType, MergeDeliveriesType, StationData,
-    SharedGraphState, SelectedElements, DeliveryId, StationId
+    SharedGraphState, SelectedElements, DeliveryId, StationId,
+    Color
 } from '../data.model';
 import { DataService } from '../services/data.service';
 import { CyNodeData, CyEdgeData, GraphServiceData, GraphElementData, EdgeId, SelectedGraphElements, NodeId } from './graph.model';
@@ -44,9 +45,9 @@ interface EdgeLinking extends Pick<CyEdgeData, 'id' | 'source' | 'target'> {
 })
 export class GraphService {
 
-    private static readonly DEFAULT_EDGE_COLOR = [0, 0, 0];
-    private static readonly DEFAULT_NODE_COLOR = [255, 255, 255];
-    private static readonly DEFAULT_GHOST_COLOR = [179, 179, 179];
+    private static readonly DEFAULT_EDGE_COLOR = { r: 0, g: 0, b: 0 };
+    private static readonly DEFAULT_NODE_COLOR = { r: 255, g: 255, b: 255 };
+    private static readonly DEFAULT_GHOST_COLOR = { r: 179, g: 179, b: 179 };
 
     private cachedState: SharedGraphState | null = null;
 
@@ -481,17 +482,17 @@ export class GraphService {
         }
     }
 
-    private mergeColors(edgeColors: number[][][]): number[][] {
+    private mergeColors(edgeColors: Color[][]): Color[] {
         const addDefaultColor = edgeColors.some(deliveryColors => deliveryColors.length === 0);
         if (addDefaultColor) {
             edgeColors = concat([[GraphService.DEFAULT_EDGE_COLOR]], edgeColors);
         }
         return _.uniqWith(concat(...edgeColors),
-            (c1: number[], c2: number[]) => c1[0] === c2[0] && c1[1] === c2[1] && c1[2] === c2[2]
+            (c1: Color, c2: Color) => c1.r === c2.r && c1.b === c2.b && c1.g === c2.g
         );
     }
 
-    private getColorInfo(colors: number[][], defaultColor: number[]): {
+    private getColorInfo(colors: Color[], defaultColor: Color): {
         stopColors: string;
         stopPositions: string;
     } {
@@ -509,8 +510,8 @@ export class GraphService {
         };
     }
 
-    private mapColor(color: number[]): string {
-        return `rgb(${color[0]},${color[1]},${color[2]})`;
+    private mapColor(color: Color): string {
+        return `rgb(${color.r},${color.g},${color.b})`;
     }
 
     private applyStationProps(data: GraphServiceData) {

--- a/src/app/tracing/graph/graph.service.ts
+++ b/src/app/tracing/graph/graph.service.ts
@@ -500,7 +500,7 @@ export class GraphService {
             colors = [defaultColor];
         }
         const repeat = (s: string) => s + ' ' + s;
-        const stopColors = colors.map(c => repeat(this.mapColor(c))).join(' ');
+        const stopColors = colors.map(c => repeat(Utils.colorToCss(c))).join(' ');
         const n = colors.length;
         const stopPositions = colors.map((c, i) => `${100 * i / n}% ${100 * (i + 1) / n}%`).join(' ');
 
@@ -508,10 +508,6 @@ export class GraphService {
             stopColors: stopColors,
             stopPositions: stopPositions
         };
-    }
-
-    private mapColor(color: Color): string {
-        return `rgb(${color.r},${color.g},${color.b})`;
     }
 
     private applyStationProps(data: GraphServiceData) {

--- a/src/app/tracing/io/data-exporter.ts
+++ b/src/app/tracing/io/data-exporter.ts
@@ -221,7 +221,7 @@ export class DataExporter {
             disabled: rule.userDisabled,
             invisible: rule.invisible,
             adjustThickness: rule.adjustThickness,
-            color: rule.color,
+            color: rule.color ? Utils.colorToRGBArray(rule.color) : null,
             labelProperty: rule.labelProperty === null ? null : intToExtPropMap[rule.labelProperty],
             valueCondition: this.mapValueCondition(rule.valueCondition, intToExtPropMap, intToExtValueTypeMap),
             logicalConditions: this.mapLogicalConditions(rule.logicalConditions, intToExtPropMap, intToExtOpTypeMap)

--- a/src/app/tracing/io/data-importer/data-importer-v1.ts
+++ b/src/app/tracing/io/data-importer/data-importer-v1.ts
@@ -8,7 +8,8 @@ import {
     ValueType, OperationType, NodeShapeType, LinePatternType,
     MergeDeliveriesType, CrossContTraceType, StationId, DeliveryId, HighlightingRule,
     LabelPart as IntLabelPart,
-    StationHighlightingRule as IntStationHighlightingRule
+    StationHighlightingRule as IntStationHighlightingRule,
+    Color
 } from '../../data.model';
 import { HttpClient } from '@angular/common/http';
 
@@ -612,7 +613,7 @@ export class DataImporterV1 implements IDataImporter {
         }
     }
 
-    private colorFromArray(colorArray: number[] | null): { r: number; g: number; b: number } | null {
+    private colorFromArray(colorArray: number[] | null): Color | null {
         return colorArray && colorArray.length === 3 ? { r: colorArray[0], g: colorArray[1], b: colorArray[2] } : null;
     }
 

--- a/src/app/tracing/io/data-importer/data-importer-v1.ts
+++ b/src/app/tracing/io/data-importer/data-importer-v1.ts
@@ -43,7 +43,7 @@ import { PartialPick } from '@app/tracing/util/utility-types';
 const JSON_SCHEMA_FILE = '../../../../assets/schema/schema-v1.json';
 
 export class DataImporterV1 implements IDataImporter {
-    constructor(private httpClient: HttpClient) {}
+    constructor(private httpClient: HttpClient) { }
 
     async isDataFormatSupported(data: any): Promise<boolean> {
         if (
@@ -173,7 +173,7 @@ export class DataImporterV1 implements IDataImporter {
             const intDelivery = intPartDelivery as DeliveryData;
 
             intDelivery.lotKey = intDelivery.lotKey ||
-                    (intDelivery.source + '|' + (intDelivery.name || intDelivery.id) + '|' + (intDelivery.lot || intDelivery.id));
+                (intDelivery.source + '|' + (intDelivery.name || intDelivery.id) + '|' + (intDelivery.lot || intDelivery.id));
 
             idToStationMap.get(intDelivery.source)!.outgoing.push(intDelivery.id);
             idToStationMap.get(intDelivery.target)!.incoming.push(intDelivery.id);
@@ -556,7 +556,7 @@ export class DataImporterV1 implements IDataImporter {
                         showInLegend: extRule.showInLegend === true,
                         userDisabled: extRule.disabled === true,
                         autoDisabled: false,
-                        color: extRule.color,
+                        color: this.colorFromArray(extRule.color),
                         invisible: extRule.invisible,
                         adjustThickness: extRule.adjustThickness,
                         labelProperty: this.mapLabelProperty(extRule.labelProperty, extToIntStatPropMap),
@@ -597,7 +597,7 @@ export class DataImporterV1 implements IDataImporter {
                         userDisabled: extRule.disabled === true,
                         autoDisabled: false,
                         activationDisablesOtherRules: false,
-                        color: extRule.color,
+                        color: this.colorFromArray(extRule.color),
                         invisible: extRule.invisible,
                         adjustThickness: extRule.adjustThickness,
                         labelProperty: this.mapLabelProperty(extRule.labelProperty, extToIntPropMap),
@@ -610,6 +610,10 @@ export class DataImporterV1 implements IDataImporter {
         } else {
             fclData.graphSettings.highlightingSettings.deliveries = createDefaultDeliveryHRules();
         }
+    }
+
+    private colorFromArray(colorArray: number[] | null): { r: number; b: number; g: number } | null {
+        return colorArray && colorArray.length === 3 ? { r: colorArray[0], b: colorArray[1], g: colorArray[2] } : null;
     }
 
     private convertExternalAnoRule(extAnoRule: ExtAnonymizationRule, extToIntPropMap: Map<string, string>): HighlightingRule {

--- a/src/app/tracing/io/data-importer/data-importer-v1.ts
+++ b/src/app/tracing/io/data-importer/data-importer-v1.ts
@@ -612,8 +612,8 @@ export class DataImporterV1 implements IDataImporter {
         }
     }
 
-    private colorFromArray(colorArray: number[] | null): { r: number; b: number; g: number } | null {
-        return colorArray && colorArray.length === 3 ? { r: colorArray[0], b: colorArray[1], g: colorArray[2] } : null;
+    private colorFromArray(colorArray: number[] | null): { r: number; g: number; b: number } | null {
+        return colorArray && colorArray.length === 3 ? { r: colorArray[0], g: colorArray[1], b: colorArray[2] } : null;
     }
 
     private convertExternalAnoRule(extAnoRule: ExtAnonymizationRule, extToIntPropMap: Map<string, string>): HighlightingRule {

--- a/src/app/tracing/io/data-importer/shared.ts
+++ b/src/app/tracing/io/data-importer/shared.ts
@@ -98,11 +98,11 @@ export function createDefaultStationHRules(addDefaultAnoRule: boolean): StationH
             id: STATION_DEFAULT_HIGHLIGHTING_RULE_ID_PREFIX + 'Outbreak',
             name: 'Outbreak',
             showInLegend: true,
-            color: [
-                255,
-                0,
-                0
-            ],
+            color: {
+                r: 255,
+                b: 0,
+                g: 0
+            },
             logicalConditions: [
                 [
                     {
@@ -118,11 +118,11 @@ export function createDefaultStationHRules(addDefaultAnoRule: boolean): StationH
             id: STATION_DEFAULT_HIGHLIGHTING_RULE_ID_PREFIX + 'Observed',
             name: 'Observed',
             showInLegend: true,
-            color: [
-                0,
-                255,
-                0
-            ],
+            color: {
+                r: 0,
+                b: 255,
+                g: 0
+            },
             logicalConditions: [
                 [
                     {
@@ -138,11 +138,11 @@ export function createDefaultStationHRules(addDefaultAnoRule: boolean): StationH
             id: STATION_DEFAULT_HIGHLIGHTING_RULE_ID_PREFIX + 'Forward Trace',
             name: 'Forward Trace',
             showInLegend: true,
-            color: [
-                255,
-                200,
-                0
-            ],
+            color: {
+                r: 255,
+                b: 200,
+                g: 0
+            },
             logicalConditions: [
                 [
                     {
@@ -158,11 +158,11 @@ export function createDefaultStationHRules(addDefaultAnoRule: boolean): StationH
             id: STATION_DEFAULT_HIGHLIGHTING_RULE_ID_PREFIX + 'Backward Trace',
             name: 'Backward Trace',
             showInLegend: true,
-            color: [
-                255,
-                0,
-                255
-            ],
+            color: {
+                r: 255,
+                b: 0,
+                g: 255
+            },
             logicalConditions: [
                 [
                     {
@@ -178,11 +178,11 @@ export function createDefaultStationHRules(addDefaultAnoRule: boolean): StationH
             id: STATION_DEFAULT_HIGHLIGHTING_RULE_ID_PREFIX + 'Cross Contamination',
             name: 'Cross Contamination',
             showInLegend: true,
-            color: [
-                0,
-                0,
-                0
-            ],
+            color: {
+                r: 0,
+                b: 0,
+                g: 0
+            },
             logicalConditions: [
                 [
                     {
@@ -198,11 +198,11 @@ export function createDefaultStationHRules(addDefaultAnoRule: boolean): StationH
             id: STATION_DEFAULT_HIGHLIGHTING_RULE_ID_PREFIX + 'Common Link',
             name: 'Common Link',
             showInLegend: true,
-            color: [
-                255,
-                255,
-                0
-            ],
+            color: {
+                r: 255,
+                b: 255,
+                g: 0
+            },
             logicalConditions: [
                 [
                     {
@@ -241,7 +241,7 @@ export function createDefaultStationHRules(addDefaultAnoRule: boolean): StationH
             id: STATION_DEFAULT_HIGHLIGHTING_RULE_ID_PREFIX + 'Kill Contamination',
             name: 'Kill Contamination',
             showInLegend: true,
-            color: [ 153, 153, 153 ],
+            color: { r: 153, b: 153, g: 153 },
             logicalConditions: [
                 [
                     {
@@ -266,11 +266,11 @@ export function createDefaultDeliveryHRules(): DeliveryHighlightingRule[] {
             id: DELIVERY_DEFAULT_HIGHLIGHTING_RULE_ID_PREFIX + 'Outbreak',
             name: 'Outbreak',
             showInLegend: true,
-            color: [
-                255,
-                0,
-                0
-            ],
+            color: {
+                r: 255,
+                b: 0,
+                g: 0
+            },
             logicalConditions: [
                 [
                     {
@@ -286,11 +286,11 @@ export function createDefaultDeliveryHRules(): DeliveryHighlightingRule[] {
             id: DELIVERY_DEFAULT_HIGHLIGHTING_RULE_ID_PREFIX + 'Observed',
             name: 'Observed',
             showInLegend: true,
-            color: [
-                0,
-                255,
-                0
-            ],
+            color: {
+                r: 0,
+                b: 255,
+                g: 0
+            },
             logicalConditions: [
                 [
                     {
@@ -306,11 +306,11 @@ export function createDefaultDeliveryHRules(): DeliveryHighlightingRule[] {
             id: DELIVERY_DEFAULT_HIGHLIGHTING_RULE_ID_PREFIX + 'Forward Trace',
             name: 'Forward Trace',
             showInLegend: true,
-            color: [
-                255,
-                200,
-                0
-            ],
+            color: {
+                r: 255,
+                b: 200,
+                g: 0
+            },
             logicalConditions: [
                 [
                     {
@@ -326,11 +326,11 @@ export function createDefaultDeliveryHRules(): DeliveryHighlightingRule[] {
             id: DELIVERY_DEFAULT_HIGHLIGHTING_RULE_ID_PREFIX + 'Backward Trace',
             name: 'Backward Trace',
             showInLegend: true,
-            color: [
-                255,
-                0,
-                255
-            ],
+            color: {
+                r: 255,
+                b: 0,
+                g: 255
+            },
             logicalConditions: [
                 [
                     {
@@ -346,7 +346,7 @@ export function createDefaultDeliveryHRules(): DeliveryHighlightingRule[] {
             id: DELIVERY_DEFAULT_HIGHLIGHTING_RULE_ID_PREFIX + 'Kill Contamination',
             name: 'Kill Contamination',
             showInLegend: true,
-            color: [ 153, 153, 153 ],
+            color: { r: 153, b: 153, g: 153 },
             logicalConditions: [
                 [
                     {

--- a/src/app/tracing/io/data-importer/shared.ts
+++ b/src/app/tracing/io/data-importer/shared.ts
@@ -100,8 +100,8 @@ export function createDefaultStationHRules(addDefaultAnoRule: boolean): StationH
             showInLegend: true,
             color: {
                 r: 255,
-                b: 0,
-                g: 0
+                g: 0,
+                b: 0
             },
             logicalConditions: [
                 [
@@ -120,8 +120,8 @@ export function createDefaultStationHRules(addDefaultAnoRule: boolean): StationH
             showInLegend: true,
             color: {
                 r: 0,
-                b: 255,
-                g: 0
+                g: 255,
+                b: 0
             },
             logicalConditions: [
                 [
@@ -140,8 +140,8 @@ export function createDefaultStationHRules(addDefaultAnoRule: boolean): StationH
             showInLegend: true,
             color: {
                 r: 255,
-                b: 200,
-                g: 0
+                g: 200,
+                b: 0
             },
             logicalConditions: [
                 [
@@ -160,8 +160,8 @@ export function createDefaultStationHRules(addDefaultAnoRule: boolean): StationH
             showInLegend: true,
             color: {
                 r: 255,
-                b: 0,
-                g: 255
+                g: 0,
+                b: 255
             },
             logicalConditions: [
                 [
@@ -180,8 +180,8 @@ export function createDefaultStationHRules(addDefaultAnoRule: boolean): StationH
             showInLegend: true,
             color: {
                 r: 0,
-                b: 0,
-                g: 0
+                g: 0,
+                b: 0
             },
             logicalConditions: [
                 [
@@ -200,8 +200,8 @@ export function createDefaultStationHRules(addDefaultAnoRule: boolean): StationH
             showInLegend: true,
             color: {
                 r: 255,
-                b: 255,
-                g: 0
+                g: 255,
+                b: 0
             },
             logicalConditions: [
                 [
@@ -241,7 +241,7 @@ export function createDefaultStationHRules(addDefaultAnoRule: boolean): StationH
             id: STATION_DEFAULT_HIGHLIGHTING_RULE_ID_PREFIX + 'Kill Contamination',
             name: 'Kill Contamination',
             showInLegend: true,
-            color: { r: 153, b: 153, g: 153 },
+            color: { r: 153, g: 153, b: 153 },
             logicalConditions: [
                 [
                     {
@@ -268,8 +268,8 @@ export function createDefaultDeliveryHRules(): DeliveryHighlightingRule[] {
             showInLegend: true,
             color: {
                 r: 255,
-                b: 0,
-                g: 0
+                g: 0,
+                b: 0
             },
             logicalConditions: [
                 [
@@ -288,8 +288,8 @@ export function createDefaultDeliveryHRules(): DeliveryHighlightingRule[] {
             showInLegend: true,
             color: {
                 r: 0,
-                b: 255,
-                g: 0
+                g: 255,
+                b: 0
             },
             logicalConditions: [
                 [
@@ -308,8 +308,8 @@ export function createDefaultDeliveryHRules(): DeliveryHighlightingRule[] {
             showInLegend: true,
             color: {
                 r: 255,
-                b: 200,
-                g: 0
+                g: 200,
+                b: 0
             },
             logicalConditions: [
                 [
@@ -328,8 +328,8 @@ export function createDefaultDeliveryHRules(): DeliveryHighlightingRule[] {
             showInLegend: true,
             color: {
                 r: 255,
-                b: 0,
-                g: 255
+                g: 0,
+                b: 255
             },
             logicalConditions: [
                 [
@@ -346,7 +346,7 @@ export function createDefaultDeliveryHRules(): DeliveryHighlightingRule[] {
             id: DELIVERY_DEFAULT_HIGHLIGHTING_RULE_ID_PREFIX + 'Kill Contamination',
             name: 'Kill Contamination',
             showInLegend: true,
-            color: { r: 153, b: 153, g: 153 },
+            color: { r: 153, g: 153, b: 153 },
             logicalConditions: [
                 [
                     {

--- a/src/app/tracing/services/highlighting.service.ts
+++ b/src/app/tracing/services/highlighting.service.ts
@@ -180,14 +180,14 @@ export class HighlightingService {
     private deliveryRuleToDisplayEntry(rule: DeliveryHighlightingRule): LegendDisplayEntry {
         return {
             name: rule.name,
-            deliveryColor: this.mapToColor(rule.color)
+            deliveryColor: rule.color ?? undefined
         };
     }
 
     private stationRuleToDisplayEntry(rule: StationHighlightingRule): LegendDisplayEntry {
         return {
             name: rule.name,
-            stationColor: this.mapToColor(rule.color),
+            stationColor: rule.color ?? undefined,
             shape: rule.shape ?? undefined
         };
     }
@@ -233,11 +233,6 @@ export class HighlightingService {
                 : { ...rule, deliveryColor: undefined }
             )
             .filter(rule => rule.deliveryColor || (rule.shape !== undefined) || rule.stationColor);
-    }
-
-
-    private mapToColor(color: number[] | null): Color | undefined {
-        return (color && color.length === 3) ? { r: color[0], g: color[1], b: color[2] } : undefined;
     }
 
     private isCommonLinkRule(rule: HighlightingRule): boolean {
@@ -402,7 +397,7 @@ export class HighlightingService {
     >(
         fclElement: T,
         highlightingRules: K[]
-    ): { label: string; color: number[][] } {
+    ): { label: string; color: Color[] } {
 
         const labelParts: string[] = [];
         for (const rule of highlightingRules) {

--- a/src/app/tracing/services/table.service.ts
+++ b/src/app/tracing/services/table.service.ts
@@ -375,7 +375,7 @@ export class TableService {
                     color: (
                         delivery.highlightingInfo!.color.length > 0 ?
                             delivery.highlightingInfo!.color :
-                            [[0, 0, 0]]
+                            [{ r: 0, b: 0, g: 0 }]
                     ),
                     shape: NodeShapeType.SQUARE
                 },

--- a/src/app/tracing/services/table.service.ts
+++ b/src/app/tracing/services/table.service.ts
@@ -375,7 +375,7 @@ export class TableService {
                     color: (
                         delivery.highlightingInfo!.color.length > 0 ?
                             delivery.highlightingInfo!.color :
-                            [{ r: 0, b: 0, g: 0 }]
+                            [{ r: 0, g: 0, b: 0 }]
                     ),
                     shape: NodeShapeType.SQUARE
                 },

--- a/src/app/tracing/util/non-ui-utils.ts
+++ b/src/app/tracing/util/non-ui-utils.ts
@@ -110,7 +110,7 @@ export class Utils {
     }
 
     static colorToCss(color: Color): string {
-        return 'rgb(' + color.r + ', ' + color.g + ', ' + color.b + ')';
+        return `rgb(${color.r},${color.g},${color.b})`;
     }
 
     static rgbToHsl(r, g, b) {


### PR DESCRIPTION
This commit refactors the number[] color values in the internal parts or the app to use {r:number, g:number, b:number} instead.
This required minor updates to the default rules and the importer.

As part of this refactor, the multiple colorToCss functions strewn around the codebase have been changed to all use Utils.colorToCss.

Ticket: Refactor color #522