### PR TITLE
Story/480 shape layered on map

### DIFF
--- a/src/app/main-page/container/toolbar-action-container/toolbar-action-container.component.html
+++ b/src/app/main-page/container/toolbar-action-container/toolbar-action-container.component.html
@@ -3,7 +3,7 @@
     [tracingActive]="tracingActive$ | async"
     [graphSettings]="graphSettings"
     [hasGisInfo]="hasGisInfo"
-    [availableMapTypes]="availableMapTypes"
+    [availableMaps]="availableMaps"
     [graphEditorActive]="graphEditorActive$ | async"
     [currentUser]="currentUser$ | async"
     [fileName]="fileName$ | async"
@@ -13,7 +13,7 @@
     (openRoaLayout)="onOpenRoaLayout()"
     (loadExampleDataFile)="onLoadExampleDataFile($event)"
     (graphType)="setGraphType($event)"
-    (mapType)="setMapType($event)"
+    (mapSettings)="setMapSettings($event)"
     (loadShapeFile)="onLoadShapeFile($event)"
     (downloadFile)="onDownloadFile($event)"
 >

--- a/src/app/main-page/container/toolbar-action-container/toolbar-action-container.component.ts
+++ b/src/app/main-page/container/toolbar-action-container/toolbar-action-container.component.ts
@@ -13,6 +13,8 @@ import {
     GraphType,
     MapType,
     DataServiceInputState,
+    AvailableMaps,
+    MapSettings,
 } from "@app/tracing/data.model";
 import { DataService } from "./../../../tracing/services/data.service";
 import { Utils as UIUtils } from "./../../../tracing/util/ui-utils";
@@ -31,6 +33,7 @@ import {
 import { Constants } from "@app/tracing/util/constants";
 import { ToolbarActionComponent } from "@app/main-page/presentation/toolbar-action/toolbar-action.component";
 import { IOService } from "@app/tracing/io/io.service";
+import { MAP_CONSTANTS } from "@app/tracing/util/map-constants";
 
 @Component({
     selector: "fcl-toolbar-action-container",
@@ -48,12 +51,7 @@ export class ToolbarActionContainerComponent implements OnInit, OnDestroy {
 
     graphSettings: GraphSettings;
     hasGisInfo = false;
-
-    availableMapTypes: MapType[] = [];
-    // the following code is commented because
-    // the Black & White Map might be deactivatd only temporaryly
-    // private mapTypes: MapType[] = [ MapType.MAPNIK, MapType.BLACK_AND_WHITE, MapType.SHAPE_FILE];
-    private mapTypes: MapType[] = [MapType.MAPNIK, MapType.SHAPE_FILE];
+    availableMaps: AvailableMaps;
 
     private componentActive: boolean = true;
 
@@ -75,16 +73,23 @@ export class ToolbarActionContainerComponent implements OnInit, OnDestroy {
                 select(tracingSelectors.selectDataServiceInputState),
             );
 
+        this.availableMaps = {
+            tiles: MAP_CONSTANTS.tiles,
+            types: [],
+            mapTypeLabels: MAP_CONSTANTS.mapTypeLabels,
+            tileServerLabels: MAP_CONSTANTS.tileServerLabels,
+        };
+
         combineLatest([graphSettings$, dataServiceInputState$])
             .pipe(takeWhile(() => this.componentActive))
             .subscribe(
                 ([graphSettings, dataServiceInputState]) => {
-                    this.availableMapTypes = this.mapTypes.filter(
-                        (mapType) =>
-                            mapType !== MapType.SHAPE_FILE ||
-                            graphSettings.shapeFileData,
-                    );
                     this.graphSettings = graphSettings;
+                    this.availableMaps.types = this.graphSettings.shapeFileData
+                        ? MAP_CONSTANTS.types.filter(
+                              (item) => item !== MapType.TILES_ONLY,
+                          )
+                        : [];
 
                     const dataServiceData: DataServiceData =
                         this.dataService.getData(dataServiceInputState);
@@ -120,9 +125,9 @@ export class ToolbarActionContainerComponent implements OnInit, OnDestroy {
         );
     }
 
-    setMapType(mapType: MapType) {
+    setMapSettings(mapSettings: MapSettings) {
         this.store.dispatch(
-            new tracingActions.SetMapTypeSOA({ mapType: mapType }),
+            new tracingActions.SetMapSettingsSOA({ mapSettings: mapSettings }),
         );
     }
 

--- a/src/app/main-page/presentation/toolbar-action/toolbar-action.component.html
+++ b/src/app/main-page/presentation/toolbar-action/toolbar-action.component.html
@@ -41,22 +41,31 @@
                 </mat-radio-button>
                 <mat-select
                     class="fcl-map-type-select"
-                    [(value)]="selectedMapTypeOption"
+                    [(value)]="selectedMapOption"
                     disableOptionCentering
                     panelClass="fcl-mat-select-below-panel-class"
                     [disabled]="!hasGisInfo"
                     matTooltip="{{ hasGisInfo ? 'Select Map Type' : '' }}"
                 >
-                    <span *ngFor="let item of availableMapTypes">
+                    <span *ngFor="let item of availableMaps.tiles">
+                        <mat-option
+                            value="{{ item }}"
+                            (click)="setTileServer(item)"
+                        >
+                            {{ availableMaps.tileServerLabels[item] }}
+                        </mat-option>
+                    </span>
+                    <span *ngFor="let item of availableMaps.types">
                         <mat-option
                             value="{{ item }}"
                             (click)="setMapType(item)"
-                            >{{ mapTypeToLabelMap.get(item) }}</mat-option
                         >
+                            {{ availableMaps.mapTypeLabels[item] }}
+                        </mat-option>
                     </span>
-                    <mat-option value="" (click)="onSelectShapeFile($event)"
-                        >Load Shape File...</mat-option
-                    >
+                    <mat-option value="" (click)="onSelectShapeFile($event)">
+                        Load Shape File...
+                    </mat-option>
                 </mat-select>
             </span>
         </mat-radio-group>

--- a/src/app/main-page/presentation/toolbar-action/toolbar-action.component.ts
+++ b/src/app/main-page/presentation/toolbar-action/toolbar-action.component.ts
@@ -14,11 +14,13 @@ import {
     GraphSettings,
     GraphType,
     MapType,
+    TileServer,
+    AvailableMaps,
+    MapSettings,
 } from "./../../../tracing/data.model";
 import { Constants } from "./../../../tracing/util/constants";
 import { ExampleData, ModelFileType } from "../../model/types";
 import { FILE_INPUT_ELEMENT_SETTINGS } from "@app/main-page/consts/consts";
-
 @Component({
     selector: "fcl-toolbar-action",
     templateUrl: "./toolbar-action.component.html",
@@ -33,15 +35,23 @@ export class ToolbarActionComponent implements OnChanges {
     @Input() tracingActive: boolean;
     @Input()
     set graphSettings(value: GraphSettings) {
-        this.selectedMapTypeOption = "" + value.mapType;
+        const { mapType, tileServer } = value;
+
+        if (mapType === MapType.TILES_ONLY) {
+            this.selectedMapOption = tileServer;
+        } else {
+            this.selectedMapOption = mapType;
+        }
+
         this._graphSettings = value;
     }
+
     get graphSettings(): GraphSettings {
         return this._graphSettings;
     }
 
     @Input() hasGisInfo: boolean;
-    @Input() availableMapTypes: MapType[];
+    @Input() availableMaps: AvailableMaps;
     @Input() graphEditorActive: boolean;
     @Input() currentUser: User;
     @Input() fileName: string | null = null;
@@ -53,22 +63,20 @@ export class ToolbarActionComponent implements OnChanges {
     @Output() openRoaLayout = new EventEmitter();
     @Output() loadExampleDataFile = new EventEmitter<ExampleData>();
     @Output() graphType = new EventEmitter<GraphType>();
-    @Output() mapType = new EventEmitter<MapType>();
+    @Output() mapSettings = new EventEmitter<Partial<MapSettings>>();
     @Output() downloadFile = new EventEmitter<string>();
 
     graphTypes = Constants.GRAPH_TYPES;
-    selectedMapTypeOption: string;
+    selectedMapOption: string;
     fileNameWoExt: string | null = null;
-
-    mapTypeToLabelMap: Map<MapType, string> = new Map([
-        [MapType.MAPNIK, "Mapnik"],
-        // the following code is commented because
-        // the Black & White Map might be deactivatd only temporaryly
-        // [MapType.BLACK_AND_WHITE, 'Black & White'],
-        [MapType.SHAPE_FILE, "Shape File"],
-    ]);
-
     exampleData: ExampleData[] = Constants.EXAMPLE_DATA_FILE_STRUCTURE;
+
+    private updateSelectedMapOption(): void {
+        this.selectedMapOption =
+            this._graphSettings.mapType === MapType.TILES_ONLY
+                ? this._graphSettings.tileServer
+                : this._graphSettings.mapType;
+    }
 
     ngOnChanges(changes: SimpleChanges): void {
         if (changes.fileName !== undefined) {
@@ -131,16 +139,24 @@ export class ToolbarActionComponent implements OnChanges {
         this.graphType.emit(this.graphSettings.type);
     }
 
-    setMapType(mapType: MapType) {
-        this.mapType.emit(mapType);
+    setMapType(mapType: MapType): void {
+        this.mapSettings.emit({ mapType: mapType });
+    }
+
+    setTileServer(tileServer: TileServer): void {
+        this.mapSettings.emit({
+            mapType: MapType.TILES_ONLY,
+            tileServer: tileServer,
+        });
     }
 
     onSelectShapeFile(event): void {
-        // this is necessary, otherwise the 'Load Shape File...' option might stay active
+        // this is necessary, otherwise the 'Load Shape File...' option might stay active, when the upload is cancelled
+        // pls note: does not work in firefox, as an input doesn't lose focus in firefox in these cases
+        // arrow func wrapper here provides the context of 'this' to the method call in the timeout
         setTimeout(() => {
-            this.selectedMapTypeOption = "" + this._graphSettings.mapType;
+            this.updateSelectedMapOption();
         }, 0);
-
         this.shapeFileInput.nativeElement.click();
     }
 }

--- a/src/app/tracing/components/graph-settings.component.ts
+++ b/src/app/tracing/components/graph-settings.component.ts
@@ -37,7 +37,7 @@ export class GraphSettingsComponent implements OnInit, OnDestroy {
 
     get isShapeFileMapActive(): boolean {
         return (
-            this.graphSettings.mapType === MapType.SHAPE_FILE &&
+            this.graphSettings.mapType !== MapType.TILES_ONLY &&
             this.graphSettings.type === GraphType.GIS
         );
     }

--- a/src/app/tracing/data.model.ts
+++ b/src/app/tracing/data.model.ts
@@ -178,12 +178,8 @@ export interface ShowElementsTraceParams {
     observedType: ObservedType;
 }
 
-export interface GraphSettings {
+export interface GraphSettings extends MapSettings, ShapeFileSettings {
     type: GraphType;
-    mapType: MapType;
-    shapeFileData: ShapeFileData | null;
-    geojsonBorderWidth: number;
-    geojsonBorderColor: Color;
     nodeSize: number;
     adjustEdgeWidthToNodeSize: boolean;
     edgeWidth: number;
@@ -203,13 +199,21 @@ export interface GraphSettings {
     ghostDelivery: DeliveryId | null;
     hoverDeliveries: DeliveryId[];
 }
-
-export interface MapConfig {
-    layout: Layout | null;
-    mapType: MapType;
+export interface ShapeStyleSettings {
+    geojsonBorderWidth: number;
+    geojsonBorderColor: Color;
+}
+export interface ShapeFileSettings extends ShapeStyleSettings {
     shapeFileData: ShapeFileData | null;
-    lineColor: Color;
-    lineWidth: number;
+}
+
+export interface MapSettings {
+    tileServer: TileServer;
+    mapType: MapType;
+}
+
+export interface MapViewConfig extends MapSettings, ShapeFileSettings {
+    layout: Layout | null;
 }
 
 export interface HighlightingSettings {
@@ -341,12 +345,23 @@ export enum GraphType {
     GIS = "GIS" as any,
 }
 
-export enum MapType {
-    SHAPE_FILE,
-    // the following code is commented because
-    // the Black & White Map might be deactivatd only temporaryly
-    // BLACK_AND_WHITE,
-    MAPNIK,
+export enum TileServer {
+    MAPNIK = "MAPNIK",
+    // the Black & White Map might be deactivatd only temporarily
+    //BLACK_AND_WHITE = "BLACK_AND_WHITE",
+}
+
+export enum MapType { // please note: the order of the keys is relevant for presentation
+    TILES_ONLY = "TILES_ONLY",
+    SHAPE_ONLY = "SHAPE_ONLY",
+    TILES_AND_SHAPE = "TILES_AND_SHAPE",
+}
+
+export interface AvailableMaps {
+    tiles: Array<TileServer>;
+    types: Array<MapType>;
+    mapTypeLabels: Record<MapType, string>;
+    tileServerLabels: Record<TileServer, string>;
 }
 
 export enum GroupMode {

--- a/src/app/tracing/graph/components/geomap/geomap.component.ts
+++ b/src/app/tracing/graph/components/geomap/geomap.component.ts
@@ -9,11 +9,10 @@ import {
 } from "@angular/core";
 import * as ol from "ol";
 import { Utils as UIUtils } from "../../../util/ui-utils";
-import { MapType, Size, MapConfig } from "../../../data.model";
+import { Size, MapViewConfig } from "../../../data.model";
 import {
     createOpenLayerMap,
-    updateMapType,
-    updateVectorLayerStyle,
+    updateMapLayers,
 } from "@app/tracing/util/map-utils";
 
 interface TypedSimpleChange<T> extends SimpleChange {
@@ -29,7 +28,7 @@ interface TypedSimpleChange<T> extends SimpleChange {
 export class GeoMapComponent implements OnChanges {
     @ViewChild("map", { static: true }) mapElement: ElementRef;
 
-    @Input() mapConfig: MapConfig;
+    @Input() mapConfig: MapViewConfig;
 
     private map: ol.Map | null = null;
 
@@ -46,7 +45,7 @@ export class GeoMapComponent implements OnChanges {
     }
 
     private processInputChanges(
-        mapConfigChange: TypedSimpleChange<MapConfig> | undefined,
+        mapConfigChange: TypedSimpleChange<MapViewConfig> | undefined,
     ): void {
         if (
             mapConfigChange !== undefined &&
@@ -77,16 +76,12 @@ export class GeoMapComponent implements OnChanges {
         };
     }
 
-    private initMap(mapConfig: MapConfig): void {
+    private initMap(mapConfig: MapViewConfig): void {
         this.map = createOpenLayerMap(mapConfig, this.mapElement.nativeElement);
         this.updateMapView(mapConfig);
     }
 
-    private updateMapType(mapConfig: MapConfig): void {
-        updateMapType(this.map!, mapConfig);
-    }
-
-    private updateMapView(mapConfig: MapConfig) {
+    private updateMapView(mapConfig: MapViewConfig) {
         if (mapConfig.layout !== null) {
             const size = this.getSize();
             this.map!.setView(
@@ -107,19 +102,12 @@ export class GeoMapComponent implements OnChanges {
         }
     }
 
-    private updateMap(newMapConfig: MapConfig, oldMapConfig: MapConfig): void {
-        if (
-            newMapConfig.mapType !== oldMapConfig.mapType ||
-            newMapConfig.shapeFileData !== oldMapConfig.shapeFileData
-        ) {
-            this.updateMapType(newMapConfig);
-        } else if (
-            newMapConfig.mapType === MapType.SHAPE_FILE &&
-            (newMapConfig.lineColor !== oldMapConfig.lineColor ||
-                newMapConfig.lineWidth !== oldMapConfig.lineWidth)
-        ) {
-            updateVectorLayerStyle(this.map!, newMapConfig);
-        }
+    private updateMap(
+        newMapConfig: MapViewConfig,
+        oldMapConfig: MapViewConfig,
+    ): void {
+        updateMapLayers(this.map!, newMapConfig, oldMapConfig);
+
         if (newMapConfig.layout !== oldMapConfig.layout) {
             this.updateMapView(newMapConfig);
         }

--- a/src/app/tracing/io/data-importer/shape-file-importer.ts
+++ b/src/app/tracing/io/data-importer/shape-file-importer.ts
@@ -6,6 +6,7 @@ import {
 import { InputDataError, InputFormatError } from "../io-errors";
 import { getJsonFromFile } from "../io-utils";
 import geojsonHintObject from "../../../../assets/geojsonhint/object";
+import { MAP_CONSTANTS } from "../../../tracing/util/map-constants";
 
 const ERROR_OLD_STYLE_CRS = "old-style crs member is not recommended";
 const UNSUPPORTED_PROJECTION_TYPE_MSG =
@@ -27,10 +28,12 @@ export async function getShapeFileData(file: File): Promise<ShapeFileData> {
     try {
         // 1. test: can an open layer map be created
         createOpenLayerMap({
-            mapType: MapType.SHAPE_FILE,
+            mapType: MapType.SHAPE_ONLY,
+            tileServer: MAP_CONSTANTS.defaults.tileServer,
             shapeFileData: jsonData,
-            lineColor: { r: 0, g: 0, b: 0 },
-            lineWidth: 0.5,
+            geojsonBorderColor: MAP_CONSTANTS.defaults.geojsonBorderColor,
+            geojsonBorderWidth: MAP_CONSTANTS.defaults.geojsonBorderWidth,
+            layout: null,
         });
         return jsonData;
     } catch (error) {

--- a/src/app/tracing/io/io.service.spec.ts
+++ b/src/app/tracing/io/io.service.spec.ts
@@ -7,12 +7,12 @@ import {
     GraphType,
     ObservedType,
     MergeDeliveriesType,
-    MapType,
     CrossContTraceType,
 } from "../data.model";
 import { JsonData, VERSION } from "./ext-data-model.v1";
 import { Constants } from "../util/constants";
 import { createInitialFclDataSourceInfo } from "../state/tracing.reducers";
+import { MAP_CONSTANTS } from "../util/map-constants";
 
 describe("IOService", () => {
     let ioService: IOService;
@@ -73,10 +73,11 @@ describe("IOService", () => {
             },
             graphSettings: {
                 type: GraphType.GRAPH,
-                mapType: MapType.MAPNIK,
+                mapType: MAP_CONSTANTS.defaults.mapType,
+                tileServer: MAP_CONSTANTS.defaults.tileServer,
                 shapeFileData: null,
-                geojsonBorderWidth: Constants.DEFAULT_GEOJSON_BORDER_WIDTH,
-                geojsonBorderColor: Constants.DEFAULT_GEOJSON_BORDER_COLOR,
+                geojsonBorderWidth: MAP_CONSTANTS.defaults.geojsonBorderWidth,
+                geojsonBorderColor: MAP_CONSTANTS.defaults.geojsonBorderColor,
                 nodeSize: Constants.DEFAULT_GRAPH_NODE_SIZE,
                 adjustEdgeWidthToNodeSize: true,
                 edgeWidth: Constants.NODE_SIZE_TO_EDGE_WIDTH_MAP.get(

--- a/src/app/tracing/state/tracing.actions.ts
+++ b/src/app/tracing/state/tracing.actions.ts
@@ -9,7 +9,6 @@ import {
     SetHighlightingSettingsPayload,
     Layout,
     MergeDeliveriesType,
-    MapType,
     ShapeFileData,
     CrossContTraceType,
     DeliveryId,
@@ -19,6 +18,7 @@ import {
     DeliveryHighlightingRule,
     JsonDataExtract,
     Color,
+    MapSettings,
 } from "../data.model";
 import { SetStationGroupsPayload } from "./../grouping/model";
 import { ActivationStatus } from "../../shared/model/types";
@@ -44,7 +44,7 @@ export enum TracingActionTypes {
     ShowConfigurationSideBarSOA = "[Tracing] Show Configuration Settings",
     ShowTableSettingsSOA = "[Tracing] Show Table Settings",
     SetGraphTypeSOA = "[Tracing] Set Graph Type",
-    SetMapTypeSOA = "[Tracing] Set Map Type",
+    SetMapSettingsSOA = "[Tracing] Set Map Settings",
     SetSchemaGraphLayoutSOA = "[Tracing] Set Schema Graph Layout",
     SetGisGraphLayoutSOA = "[Tracing] Set Gis Graph Layout",
     SetNodeSizeSOA = "[Tracing] Set Node Size",
@@ -158,10 +158,10 @@ export class SetGraphTypeSOA implements Action {
     constructor(public payload: { graphType: GraphType }) {}
 }
 
-export class SetMapTypeSOA implements Action {
-    readonly type = TracingActionTypes.SetMapTypeSOA;
+export class SetMapSettingsSOA implements Action {
+    readonly type = TracingActionTypes.SetMapSettingsSOA;
 
-    constructor(public payload: { mapType: MapType }) {}
+    constructor(public payload: { mapSettings: Partial<MapSettings> }) {}
 }
 
 export class SetNodeSizeSOA implements Action {
@@ -437,7 +437,7 @@ export type TracingActions =
     | SetSchemaGraphLayoutSOA
     | SetGisGraphLayoutSOA
     | SetGraphTypeSOA
-    | SetMapTypeSOA
+    | SetMapSettingsSOA
     | SetNodeSizeSOA
     | SetAdjustEdgeWidthToNodeSizeSOA
     | SetEdgeWidthSOA

--- a/src/app/tracing/state/tracing.reducers.ts
+++ b/src/app/tracing/state/tracing.reducers.ts
@@ -35,6 +35,7 @@ import {
     DENOVO_DELIVERY_PROP_INT_TO_EXT_MAP,
     DENOVO_STATION_PROP_INT_TO_EXT_MAP,
 } from "../io/data-mappings/data-mappings-v1";
+import { MAP_CONSTANTS } from "../util/map-constants";
 
 export const STATE_SLICE_NAME = "tracing";
 
@@ -147,10 +148,11 @@ export function createInitialFclDataState(): FclData {
             },
             schemaLayout: null,
             gisLayout: null,
-            mapType: Constants.DEFAULT_MAP_TYPE,
+            mapType: MAP_CONSTANTS.defaults.mapType,
+            tileServer: MAP_CONSTANTS.defaults.tileServer,
             shapeFileData: null,
-            geojsonBorderWidth: Constants.DEFAULT_GEOJSON_BORDER_WIDTH,
-            geojsonBorderColor: Constants.DEFAULT_GEOJSON_BORDER_COLOR,
+            geojsonBorderWidth: MAP_CONSTANTS.defaults.geojsonBorderWidth,
+            geojsonBorderColor: MAP_CONSTANTS.defaults.geojsonBorderColor,
             ghostStation: null,
             ghostDelivery: null,
             hoverDeliveries: [],
@@ -243,7 +245,7 @@ export function reducer(
                 },
             };
 
-        case TracingActionTypes.SetMapTypeSOA:
+        case TracingActionTypes.SetMapSettingsSOA:
             return {
                 ...state,
                 fclData: {
@@ -251,7 +253,7 @@ export function reducer(
                     graphSettings: {
                         ...state.fclData.graphSettings,
                         type: GraphType.GIS,
-                        mapType: action.payload.mapType,
+                        ...action.payload.mapSettings,
                     },
                 },
             };
@@ -264,12 +266,12 @@ export function reducer(
                     graphSettings: {
                         ...state.fclData.graphSettings,
                         type: GraphType.GIS,
-                        mapType: MapType.SHAPE_FILE,
+                        mapType: MapType.SHAPE_ONLY,
                         shapeFileData: action.payload.shapeFileData,
                         geojsonBorderWidth:
-                            Constants.DEFAULT_GEOJSON_BORDER_WIDTH,
+                            MAP_CONSTANTS.defaults.geojsonBorderWidth,
                         geojsonBorderColor:
-                            Constants.DEFAULT_GEOJSON_BORDER_COLOR,
+                            MAP_CONSTANTS.defaults.geojsonBorderColor,
                     },
                 },
             };

--- a/src/app/tracing/state/tracing.selectors.ts
+++ b/src/app/tracing/state/tracing.selectors.ts
@@ -221,6 +221,11 @@ const selectGisGraphLayout = createSelector(
     (graphSettings) => graphSettings.gisLayout,
 );
 
+const selectTileServer = createSelector(
+    getGraphSettings,
+    (graphSettings) => graphSettings.tileServer,
+);
+
 const selectMapType = createSelector(
     getGraphSettings,
     (graphSettings) => graphSettings.mapType,
@@ -236,10 +241,12 @@ export const selectGisGraphState = createSelector(
     selectGisGraphLayout,
     selectMapType,
     selectShapeFileData,
-    (sharedGraphState, layout, mapType, shapeFileData) => ({
+    selectTileServer,
+    (sharedGraphState, layout, mapType, shapeFileData, tileServer) => ({
         ...sharedGraphState,
         layout: layout,
         mapType: mapType,
+        tileServer: tileServer,
         shapeFileData: shapeFileData,
     }),
 );
@@ -260,12 +267,21 @@ export const getMapConfig = createSelector(
     selectShapeFileData,
     selectGeojsonBorderColor,
     selectGeojsonBorderWidth,
-    (gisLayout, mapType, shapeFileData, borderColor, borderWidth) => ({
+    selectTileServer,
+    (
+        gisLayout,
+        mapType,
+        shapeFileData,
+        borderColor,
+        borderWidth,
+        tileServer,
+    ) => ({
         layout: gisLayout,
         mapType: mapType,
+        tileServer: tileServer,
         shapeFileData: shapeFileData,
-        lineColor: borderColor,
-        lineWidth: borderWidth,
+        geojsonBorderColor: borderColor,
+        geojsonBorderWidth: borderWidth,
     }),
 );
 

--- a/src/app/tracing/util/colors.ts
+++ b/src/app/tracing/util/colors.ts
@@ -1,0 +1,4 @@
+import { Color } from "../data.model";
+export const COLORS: Record<string, Color> = {
+    black: { r: 0, g: 0, b: 0 },
+};

--- a/src/app/tracing/util/constants.ts
+++ b/src/app/tracing/util/constants.ts
@@ -1,7 +1,6 @@
 import {
     Color,
     GraphType,
-    MapType,
     DeliveryData,
     StationData,
     GroupType,
@@ -199,15 +198,9 @@ export class Constants {
     );
 
     static readonly GEOJSON_BORDER_WIDTHS = Constants.EDGE_WIDTHS;
-    static readonly DEFAULT_GEOJSON_BORDER_WIDTH = 0.5;
-    static readonly DEFAULT_GEOJSON_BORDER_COLOR = {
-        r: 0,
-        g: 0,
-        b: 0,
-    } as Readonly<Color>;
 
     static readonly DEFAULT_GRAPH_TYPE = GraphType.GRAPH;
-    static readonly DEFAULT_MAP_TYPE = MapType.MAPNIK;
+
     static readonly DEFAULT_GRAPH_NODE_SIZE = 14;
     static readonly DEFAULT_GRAPH_ADJUST_EDGE_WIDTH_TO_NODE_SIZE = true;
     static readonly DEFAULT_GRAPH_EDGE_WIDTH =

--- a/src/app/tracing/util/map-constants.ts
+++ b/src/app/tracing/util/map-constants.ts
@@ -1,0 +1,29 @@
+import { MapType, TileServer } from "../data.model";
+import { COLORS } from "./colors";
+
+export const MAP_CONSTANTS = {
+    types: [
+        MapType.TILES_ONLY,
+        MapType.SHAPE_ONLY,
+        MapType.TILES_AND_SHAPE,
+    ] as Array<MapType>, // please note: array - so order is relevant!
+    tiles: [
+        TileServer.MAPNIK,
+        //TileServer.BLACK_AND_WHITE,
+    ] as Array<TileServer>, // please note: array - so order is relevant!
+    tileServerLabels: {
+        [TileServer.MAPNIK]: "Mapnik",
+        //temporarily deactivated, therefore just a comment and not removed
+        //[TileServer.BLACK_AND_WHITE]: "Black & White",
+    } as Record<TileServer, string>,
+    mapTypeLabels: {
+        [MapType.SHAPE_ONLY]: "Shape File",
+        [MapType.TILES_AND_SHAPE]: "Map & Shape File",
+    } as Record<MapType, string>,
+    defaults: {
+        mapType: MapType.TILES_ONLY,
+        tileServer: TileServer.MAPNIK,
+        geojsonBorderWidth: 0.5,
+        geojsonBorderColor: COLORS.black,
+    },
+};


### PR DESCRIPTION
Users can now choose between a map, a shape file and a shape file on a map. The last option becomes active, once a shape file has been uploaded. It is not visible when no shape file data is present. The user can switch back and forth between the options. Once the black and white version of the map has been reactivated, the user can also choose this option. If they choose the option shape file & map, the shape file will be projected onto the last map the user has chosen - or the regular map, if no selection has been made before (default).

Please note: To test the last bit - search for 'BLACK_AND_WHITE' in files, and uncomment this option in all places.

(Will squash, once you're satisfied with the code.)