### PR TITLE
fixes row overlay in firefox browsers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "@ngrx/effects": "^15.4.0",
                 "@ngrx/store": "^15.4.0",
                 "@ngrx/store-devtools": "^15.4.0",
-                "@swimlane/ngx-datatable": "^20.1.0",
+                "@siemens/ngx-datatable": "^21.3.2",
                 "ajv": "^6.12.6",
                 "core-js": "^3.33.0",
                 "css-element-queries": "^1.2.3",
@@ -7013,6 +7013,20 @@
                 "yarn": ">= 1.13.0"
             }
         },
+        "node_modules/@siemens/ngx-datatable": {
+            "version": "21.3.2",
+            "resolved": "https://registry.npmjs.org/@siemens/ngx-datatable/-/ngx-datatable-21.3.2.tgz",
+            "integrity": "sha512-qXamxgvsCjXece1AST/tsoRACH9jTHnmra0mpnY6MS9D1Le8QLj9spfkCrXMYWQAFTMyUE7nDTHwDEJ3P0ZLyA==",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "@angular/common": ">=11.0.2",
+                "@angular/core": ">=11.0.2",
+                "@angular/platform-browser": ">=11.0.2",
+                "rxjs": "^6.6.3 || ^7.4.0"
+            }
+        },
         "node_modules/@sigstore/bundle": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-1.1.0.tgz",
@@ -7153,20 +7167,6 @@
             "dev": true,
             "dependencies": {
                 "@sinonjs/commons": "^3.0.0"
-            }
-        },
-        "node_modules/@swimlane/ngx-datatable": {
-            "version": "20.1.0",
-            "resolved": "https://registry.npmjs.org/@swimlane/ngx-datatable/-/ngx-datatable-20.1.0.tgz",
-            "integrity": "sha512-oHnnx1QRNmv10l5UME13v5JP3M3GesM9K3QH6TRYo2C7UbbhY7vL5EZ4HGqcvtMMW4FOzqNOSltE++IVL99F3g==",
-            "dependencies": {
-                "tslib": "^2.0.0"
-            },
-            "peerDependencies": {
-                "@angular/common": ">=11.0.2",
-                "@angular/core": ">=11.0.2",
-                "@angular/platform-browser": ">=11.0.2",
-                "rxjs": "^6.6.3 || ^7.4.0"
             }
         },
         "node_modules/@tootallnate/once": {
@@ -29139,6 +29139,14 @@
                 "jsonc-parser": "3.2.0"
             }
         },
+        "@siemens/ngx-datatable": {
+            "version": "21.3.2",
+            "resolved": "https://registry.npmjs.org/@siemens/ngx-datatable/-/ngx-datatable-21.3.2.tgz",
+            "integrity": "sha512-qXamxgvsCjXece1AST/tsoRACH9jTHnmra0mpnY6MS9D1Le8QLj9spfkCrXMYWQAFTMyUE7nDTHwDEJ3P0ZLyA==",
+            "requires": {
+                "tslib": "^2.0.0"
+            }
+        },
         "@sigstore/bundle": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-1.1.0.tgz",
@@ -29254,14 +29262,6 @@
             "dev": true,
             "requires": {
                 "@sinonjs/commons": "^3.0.0"
-            }
-        },
-        "@swimlane/ngx-datatable": {
-            "version": "20.1.0",
-            "resolved": "https://registry.npmjs.org/@swimlane/ngx-datatable/-/ngx-datatable-20.1.0.tgz",
-            "integrity": "sha512-oHnnx1QRNmv10l5UME13v5JP3M3GesM9K3QH6TRYo2C7UbbhY7vL5EZ4HGqcvtMMW4FOzqNOSltE++IVL99F3g==",
-            "requires": {
-                "tslib": "^2.0.0"
             }
         },
         "@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "@ngrx/effects": "^15.4.0",
         "@ngrx/store": "^15.4.0",
         "@ngrx/store-devtools": "^15.4.0",
-        "@swimlane/ngx-datatable": "^20.1.0",
+        "@siemens/ngx-datatable": "^21.3.2",
         "ajv": "^6.12.6",
         "core-js": "^3.33.0",
         "css-element-queries": "^1.2.3",

--- a/src/app/main-page/main-page.module.ts
+++ b/src/app/main-page/main-page.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { ScrollbarHelper } from "@swimlane/ngx-datatable";
+import { ScrollbarHelper } from "@siemens/ngx-datatable";
 
 import { SharedModule } from "./../shared/shared.module";
 import { MainPageRoutingModule } from "./main-page.routing.module";

--- a/src/app/tracing/configuration/filter-table-view/filter-table-utils.ts
+++ b/src/app/tracing/configuration/filter-table-view/filter-table-utils.ts
@@ -3,7 +3,7 @@ import {
     SortPropDir,
     SortDirection,
     orderByComparator,
-} from "@swimlane/ngx-datatable";
+} from "@siemens/ngx-datatable";
 import { NodeShapeType, TableRow } from "@app/tracing/data.model";
 
 type SortableColumn = Pick<NgxTableColumn, "prop" | "comparator">;

--- a/src/app/tracing/configuration/filter-table-view/filter-table-view.component.ts
+++ b/src/app/tracing/configuration/filter-table-view/filter-table-view.component.ts
@@ -21,7 +21,7 @@ import {
     SelectionType,
     TableColumn as NgxTableColumn,
     SortPropDir,
-} from "@swimlane/ngx-datatable";
+} from "@siemens/ngx-datatable";
 import {
     DataTable,
     TableRow,
@@ -1108,5 +1108,6 @@ export class FilterTableViewComponent
             orderedFilterColumns,
             filterColumns.filter((c) => !orderedFilterColumns.includes(c)),
         );
+        this.table.recalculate();
     }
 }

--- a/src/app/tracing/configuration/ngxdatatable-row-event-provider.directive.ts
+++ b/src/app/tracing/configuration/ngxdatatable-row-event-provider.directive.ts
@@ -6,7 +6,7 @@ import {
     EventEmitter,
     Output,
 } from "@angular/core";
-import { DatatableComponent } from "@swimlane/ngx-datatable";
+import { DatatableComponent } from "@siemens/ngx-datatable";
 import { Subscription } from "rxjs";
 import { TableRow } from "../data.model";
 

--- a/src/app/tracing/configuration/sortable-header-cell-view.component.ts
+++ b/src/app/tracing/configuration/sortable-header-cell-view.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, Output, EventEmitter } from "@angular/core";
 import { TableColumn } from "@app/tracing/data.model";
-import { SortDirection } from "@swimlane/ngx-datatable";
+import { SortDirection } from "@siemens/ngx-datatable";
 
 @Component({
     template: "",

--- a/src/app/tracing/dialog/deliveries-properties/deliveries-properties.component.ts
+++ b/src/app/tracing/dialog/deliveries-properties/deliveries-properties.component.ts
@@ -3,7 +3,7 @@ import {
     MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA,
     MatLegacyDialogRef as MatDialogRef,
 } from "@angular/material/legacy-dialog";
-import { DatatableComponent } from "@swimlane/ngx-datatable";
+import { DatatableComponent } from "@siemens/ngx-datatable";
 import { Subscription, timer } from "rxjs";
 import { concat, Utils } from "@app/tracing/util/non-ui-utils";
 import { TableService } from "@app/tracing/services/table.service";

--- a/src/app/tracing/shared/ngxdatatable-scroll-fix.directive.ts
+++ b/src/app/tracing/shared/ngxdatatable-scroll-fix.directive.ts
@@ -8,7 +8,7 @@ import {
     ChangeDetectorRef,
     DoCheck,
 } from "@angular/core";
-import { DatatableComponent } from "@swimlane/ngx-datatable";
+import { DatatableComponent } from "@siemens/ngx-datatable";
 import { Observable, Subscription } from "rxjs";
 import { ActivityState } from "../configuration/configuration.model";
 import { Size } from "../data.model";

--- a/src/app/tracing/tracing.module.ts
+++ b/src/app/tracing/tracing.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { FormsModule } from "@angular/forms";
-import { NgxDatatableModule } from "@swimlane/ngx-datatable";
+import { NgxDatatableModule } from "@siemens/ngx-datatable";
 import { ColorPickerModule } from "ngx-color-picker";
 import { MainTracingComponent } from "./components/main-tracing.component";
 import { SharedModule } from "../shared/shared.module";

--- a/src/ngx-datatable-style.scss
+++ b/src/ngx-datatable-style.scss
@@ -1,4 +1,4 @@
-@use "node_modules/@swimlane/ngx-datatable/themes/material.scss";
+@use "node_modules/@siemens/ngx-datatable/themes/material.scss";
 @use "src/assets/sass/base" as fcl;
 @use "sass:map";
 
@@ -8,6 +8,14 @@ ngx-datatable {
         0 1px 3px 0 rgb(0 0 0 / 0.12),
         0 1px 2px 0 rgb(0 0 0 / 0.24);
     font-family: Roboto, "Helvetica Neue", sans-serif;
+}
+
+.ngx-datatable.material {
+    .datatable-body {
+        .datatable-body-row {
+            border-bottom-style: none;
+        }
+    }
 }
 
 .fcl-datatable {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,7 +1,7 @@
 @use "@angular/material" as mat;
 @use "node_modules/normalize.css/normalize.css";
-@use "node_modules/@swimlane/ngx-datatable/index.css";
-@use "node_modules/@swimlane/ngx-datatable/assets/icons.css";
+@use "node_modules/@siemens/ngx-datatable/index.css";
+@use "node_modules/@siemens/ngx-datatable/assets/icons.css";
 @use "node_modules/ol/ol.css";
 @use "assets/sass/base" as fcl;
 @use "material-style";


### PR DESCRIPTION
replaces dependency @swimlane/ngx-datatable v20.1.0 with @siemens/ngx-datatable v21.3.2

adds global ngx-datatable style adjustment (v21.2.0 introduced a row bottom border) to prevent row bottom borders

Background: Since Firefox v126 rows in the filtertable were overlaying each other. But @swimlane/ngx-datatable seems to be maintained not anymore (last release 2022, no maintainer feedback to reported issues). @siemens/ngx-datatable was forked of @swimlane/ngx-datatable because of the lacking maintenance.

ticket: #782