### PR TITLE
Fixes upload model bug in safari

### DIFF
--- a/src/app/main-page/container/toolbar-action-container/toolbar-action-container.component.html
+++ b/src/app/main-page/container/toolbar-action-container/toolbar-action-container.component.html
@@ -9,7 +9,7 @@
     [currentUser]="currentUser$ | async"
     [fileName]="fileName$ | async"
     (loadModelFile)="loadModelFile($event)"
-    (selectModelFile)="onSelectModelFile($event)"
+    (selectModelFileOpenMenu)="onSelectModelFileOpenMenu()"
     (saveImage)="onSaveImage()"
     (openRoaLayout)="onOpenRoaLayout()"
     (loadExampleDataFile)="onLoadExampleDataFile($event)"

--- a/src/app/main-page/container/toolbar-action-container/toolbar-action-container.component.ts
+++ b/src/app/main-page/container/toolbar-action-container/toolbar-action-container.component.ts
@@ -104,16 +104,14 @@ export class ToolbarActionContainerComponent implements OnInit, OnDestroy {
             );
     }
 
-    loadModelFile(fileList: FileList) {
-        this.loadFile(fileList);
+    onSelectModelFileOpenMenu() {
+        this.checkConditionsAndLoadFile(() => {
+            this.toolbarActionComponent.openSelectModelFileMenu();
+        });
     }
 
-    onSelectModelFile(type: ModelFileType) {
-        this.checkConditionsAndLoadFile(() =>
-            this.toolbarActionComponent.prepareAndClickModelFileInputElement(
-                type,
-            ),
-        );
+    loadModelFile(fileList: FileList) {
+        this.loadFile(fileList);
     }
 
     onLoadExampleDataFile(exampleData: ExampleData) {

--- a/src/app/main-page/presentation/toolbar-action/toolbar-action.component.html
+++ b/src/app/main-page/presentation/toolbar-action/toolbar-action.component.html
@@ -118,6 +118,14 @@
         <button mat-menu-item (click)="onSelectModelFile('xlsx-all-in-one')">
             FCL All-in-one template (.xlsx)
         </button>
+        <button
+            mat-menu-item
+            (click)="onSelectModelFile('json-fcl')"
+            matTooltip="Coming soon"
+            disabled
+        >
+            UTX file (.json)
+        </button>
     </mat-menu>
     <button
         class="fcl-separator fcl-no-shrink"

--- a/src/app/main-page/presentation/toolbar-action/toolbar-action.component.html
+++ b/src/app/main-page/presentation/toolbar-action/toolbar-action.component.html
@@ -98,16 +98,18 @@
         #modelFileInput
         data-cy="fcl-upload-model-fileinput"
     />
-    <button
-        class="fcl-no-shrink"
-        mat-button
-        data-cy="fcl-upload-model-button"
-        [matMenuTriggerFor]="uploadMenu"
-        matTooltip="Upload data"
-    >
-        <mat-icon>file_upload</mat-icon>
-        Upload Data
-    </button>
+    <div #openUploadMenu="matMenuTrigger" [matMenuTriggerFor]="uploadMenu">
+        <button
+            class="fcl-no-shrink"
+            mat-button
+            data-cy="fcl-upload-model-button"
+            matTooltip="Upload data"
+            (click)="onSelectModelFileOpenMenu($event)"
+        >
+            <mat-icon>file_upload</mat-icon>
+            Upload Data
+        </button>
+    </div>
     <!-- (click)="onSelectModelFile()" -->
     <mat-menu #uploadMenu="matMenu">
         <button mat-menu-item (click)="onSelectModelFile('json-fcl')">

--- a/src/app/main-page/presentation/toolbar-action/toolbar-action.component.ts
+++ b/src/app/main-page/presentation/toolbar-action/toolbar-action.component.ts
@@ -21,6 +21,7 @@ import {
 import { Constants } from "./../../../tracing/util/constants";
 import { ExampleData, ModelFileType } from "../../model/types";
 import { FILE_INPUT_ELEMENT_SETTINGS } from "@app/main-page/consts/consts";
+import { MatMenuTrigger } from "@angular/material/menu";
 @Component({
     selector: "fcl-toolbar-action",
     templateUrl: "./toolbar-action.component.html",
@@ -31,6 +32,7 @@ export class ToolbarActionComponent implements OnChanges {
 
     @ViewChild("modelFileInput") modelFileInput: ElementRef<HTMLInputElement>;
     @ViewChild("shapeFileInput") shapeFileInput: ElementRef<HTMLInputElement>;
+    @ViewChild("openUploadMenu") openUploadMenuTrigger: MatMenuTrigger;
 
     @Input() tracingActive: boolean;
     @Input() isModelLoaded: boolean;
@@ -60,6 +62,7 @@ export class ToolbarActionComponent implements OnChanges {
     @Output() loadModelFile = new EventEmitter<FileList>();
     @Output() loadShapeFile = new EventEmitter<FileList>();
     @Output() selectModelFile = new EventEmitter<ModelFileType>();
+    @Output() selectModelFileOpenMenu = new EventEmitter<void>();
     @Output() saveImage = new EventEmitter();
     @Output() openRoaLayout = new EventEmitter();
     @Output() loadExampleDataFile = new EventEmitter<ExampleData>();
@@ -88,6 +91,16 @@ export class ToolbarActionComponent implements OnChanges {
         }
     }
 
+    openSelectModelFileMenu() {
+        this.openUploadMenuTrigger.openMenu();
+    }
+
+    onSelectModelFileOpenMenu(event) {
+        // prevent menu from opening, before we check if data has been loaded and altered
+        event.stopPropagation();
+        this.selectModelFileOpenMenu.emit();
+    }
+
     isServerLess(): boolean {
         return environment.serverless;
     }
@@ -105,10 +118,6 @@ export class ToolbarActionComponent implements OnChanges {
     }
 
     onSelectModelFile(type: ModelFileType) {
-        this.selectModelFile.emit(type);
-    }
-
-    prepareAndClickModelFileInputElement(type: ModelFileType) {
         this.modelFileInput.nativeElement.accept =
             FILE_INPUT_ELEMENT_SETTINGS[type].accept;
         this.modelFileInput.nativeElement.click();


### PR DESCRIPTION
In Safari, users were only able to upload data when no example or other data had been loaded before.This was due to the input type=file being programmatically triggered in an async function, which is a security violation for safari. This moves the check the async function performs onto the upload menu opening button, so that we don't lose the trusted context for the input type=file click.

Ticket: #761