### PR TITLE
Ticket #888: Adds data upload warnings symbol and modal - Part 1

### DIFF
--- a/src/app/main-page/container/toolbar-action-container/toolbar-action-container.component.html
+++ b/src/app/main-page/container/toolbar-action-container/toolbar-action-container.component.html
@@ -17,5 +17,6 @@
     (mapSettings)="setMapSettings($event)"
     (loadShapeFile)="onLoadShapeFile($event)"
     (downloadFile)="onDownloadFile($event)"
+    (openWarningsDialog)="onOpenWarningsDialog()"
 >
 </fcl-toolbar-action>

--- a/src/app/main-page/container/toolbar-action-container/toolbar-action-container.component.ts
+++ b/src/app/main-page/container/toolbar-action-container/toolbar-action-container.component.ts
@@ -34,6 +34,7 @@ import { Constants } from "@app/tracing/util/constants";
 import { ToolbarActionComponent } from "@app/main-page/presentation/toolbar-action/toolbar-action.component";
 import { IOService } from "@app/tracing/io/io.service";
 import { MAP_CONSTANTS } from "@app/tracing/util/map-constants";
+import { DialogImportWarningsComponent } from "@app/tracing/dialog/dialog-import-warnings/dialog-import-warnings.component";
 
 @Component({
     selector: "fcl-toolbar-action-container",
@@ -146,6 +147,13 @@ export class ToolbarActionContainerComponent implements OnInit, OnDestroy {
 
     onOpenRoaLayout() {
         this.mainPageService.onROALayout();
+    }
+
+    onOpenWarningsDialog() {
+        this.dialog.open(DialogImportWarningsComponent, {
+            // to do: add issues
+            data: "add issues here",
+        });
     }
 
     ngOnDestroy() {

--- a/src/app/main-page/presentation/toolbar-action/toolbar-action.component.html
+++ b/src/app/main-page/presentation/toolbar-action/toolbar-action.component.html
@@ -6,8 +6,22 @@
         *ngIf="fileName !== null"
         class="fcl-file-name-wrapper fcl-separator mat-body"
     >
-        <div class="fcl-file-name" [matTooltip]="fileName">
-            File: {{ fileNameWoExt }}
+        <div class="fcl-file-name-inner-wrapper">
+            <div class="fcl-file-name" [matTooltip]="fileName">
+                <span>File: {{ fileNameWoExt }}</span>
+            </div>
+            <button
+                class="fcl-file-name-warning"
+                *ngIf="dataImportHasWarnings"
+                (click)="onOpenWarningsDialog()"
+                matTooltip="Data import warnings"
+            >
+                <mat-icon
+                    aria-hidden="false"
+                    aria-label="Data import warnings icon"
+                    fontIcon="warning"
+                ></mat-icon>
+            </button>
         </div>
     </div>
     <div class="fcl-graph-type fcl-separator mat-body">

--- a/src/app/main-page/presentation/toolbar-action/toolbar-action.component.scss
+++ b/src/app/main-page/presentation/toolbar-action/toolbar-action.component.scss
@@ -1,5 +1,15 @@
 @use "../../../../assets/sass/base" as fcl;
 
+@mixin common-marker-styles {
+    background-color: rgb(192 0 0);
+    color: white;
+    padding-left: 0.5ch;
+    padding-right: 0.5ch;
+    bottom: 0.9em;
+}
+
+$marker-offset-right: -1.5ch;
+
 .fcl-action-item {
     flex: 1;
 }
@@ -34,10 +44,27 @@
     padding-right: 1rem;
 }
 
+.fcl-file-name-inner-wrapper {
+    position: relative;
+}
+
 .fcl-file-name {
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
+}
+
+.fcl-file-name-warning {
+    position: absolute;
+    right: $marker-offset-right;
+    display: flex;
+    align-items: center;
+    appearance: none;
+    border: 0;
+    padding: 0;
+    margin: 0;
+
+    @include common-marker-styles;
 }
 
 .fcl-graph-type {
@@ -77,19 +104,16 @@
 }
 
 .fcl-draft-marker {
+    @include common-marker-styles;
+
     display: block;
     position: relative;
     left: 0;
-    bottom: 0.9em;
     line-height: 1.2em;
-    background-color: rgb(192 0 0);
-    color: white;
-    padding-left: 0.5ch;
-    padding-right: 0.5ch;
 }
 
 .fcl-draft-marker-wrapper {
     display: inline-block;
     margin-left: -2.5ch;
-    margin-right: -1.5ch;
+    margin-right: $marker-offset-right;
 }

--- a/src/app/main-page/presentation/toolbar-action/toolbar-action.component.ts
+++ b/src/app/main-page/presentation/toolbar-action/toolbar-action.component.ts
@@ -58,6 +58,7 @@ export class ToolbarActionComponent implements OnChanges {
     @Input() graphEditorActive: boolean;
     @Input() currentUser: User;
     @Input() fileName: string | null = null;
+    @Input() dataImportHasWarnings: boolean = false;
     @Output() toggleRightSidebar = new EventEmitter<boolean>();
     @Output() loadModelFile = new EventEmitter<FileList>();
     @Output() loadShapeFile = new EventEmitter<FileList>();
@@ -69,6 +70,7 @@ export class ToolbarActionComponent implements OnChanges {
     @Output() graphType = new EventEmitter<GraphType>();
     @Output() mapSettings = new EventEmitter<Partial<MapSettings>>();
     @Output() downloadFile = new EventEmitter<string>();
+    @Output() openWarningsDialog = new EventEmitter<void>();
 
     graphTypes = Constants.GRAPH_TYPES;
     selectedMapOption: string;
@@ -89,6 +91,10 @@ export class ToolbarActionComponent implements OnChanges {
                     ? null
                     : this.fileName.replace(/\.[^\.]+$/, "");
         }
+    }
+
+    onOpenWarningsDialog() {
+        this.openWarningsDialog.emit();
     }
 
     openSelectModelFileMenu() {

--- a/src/app/tracing/dialog/dialog-import-warnings/dialog-import-warnings.component.html
+++ b/src/app/tracing/dialog/dialog-import-warnings/dialog-import-warnings.component.html
@@ -1,0 +1,15 @@
+<fcl-dialog-movable>
+    <div mat-dialog-content>
+        <mat-card>
+            <mat-card-title>
+                <span>Data import warnings</span>
+            </mat-card-title>
+            <mat-card-content>
+                {{ data }}
+            </mat-card-content>
+        </mat-card>
+    </div>
+    <div mat-dialog-actions>
+        <button mat-button cdkFocusInitial matDialogClose>Close</button>
+    </div>
+</fcl-dialog-movable>

--- a/src/app/tracing/dialog/dialog-import-warnings/dialog-import-warnings.component.scss
+++ b/src/app/tracing/dialog/dialog-import-warnings/dialog-import-warnings.component.scss
@@ -1,0 +1,7 @@
+mat-card {
+    margin: 10px 0;
+}
+
+mat-card:not(:last-child) {
+    margin-bottom: 20px;
+}

--- a/src/app/tracing/dialog/dialog-import-warnings/dialog-import-warnings.component.ts
+++ b/src/app/tracing/dialog/dialog-import-warnings/dialog-import-warnings.component.ts
@@ -1,0 +1,11 @@
+import { Component, Inject } from "@angular/core";
+import { MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA } from "@angular/material/legacy-dialog";
+
+@Component({
+    selector: "fcl-dialog-import-warnings",
+    templateUrl: "./dialog-import-warnings.component.html",
+    styleUrls: ["./dialog-import-warnings.component.scss"],
+})
+export class DialogImportWarningsComponent {
+    constructor(@Inject(MAT_DIALOG_DATA) public data: any) {}
+}

--- a/src/app/tracing/dialog/dialog-movable/dialog-movable.component.html
+++ b/src/app/tracing/dialog/dialog-movable/dialog-movable.component.html
@@ -1,0 +1,10 @@
+<div
+    cdkDrag
+    cdkDragRootElement=".cdk-overlay-pane"
+    cdkDragBoundary=".cdk-overlay-container"
+>
+    <div class="fcl-drag-handle">
+        <mat-icon cdkDragHandle fill="currentColor">open_with</mat-icon>
+    </div>
+    <ng-content />
+</div>

--- a/src/app/tracing/dialog/dialog-movable/dialog-movable.component.scss
+++ b/src/app/tracing/dialog/dialog-movable/dialog-movable.component.scss
@@ -1,0 +1,8 @@
+.fcl-drag-handle {
+    display: flex;
+    justify-content: flex-end;
+
+    mat-icon {
+        cursor: move;
+    }
+}

--- a/src/app/tracing/dialog/dialog-movable/dialog-movable.component.ts
+++ b/src/app/tracing/dialog/dialog-movable/dialog-movable.component.ts
@@ -1,0 +1,12 @@
+import { Component, Inject } from "@angular/core";
+import {
+    MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA,
+    MatLegacyDialogRef as MatDialogRef,
+} from "@angular/material/legacy-dialog";
+
+@Component({
+    selector: "fcl-dialog-movable",
+    templateUrl: "./dialog-movable.component.html",
+    styleUrls: ["./dialog-movable.component.scss"],
+})
+export class DialogMovableComponent {}

--- a/src/app/tracing/tracing.module.ts
+++ b/src/app/tracing/tracing.module.ts
@@ -84,6 +84,8 @@ import { CollapseStatusCellViewComponent } from "./configuration/table-cells/col
 import { SymbolHeaderCellViewComponent } from "./configuration/table-cells/symbol-header-cell-view/symbol-header-cell-view.component";
 import { PrefixEditorViewComponent } from "./configuration/prefix-editor-view/prefix-editor-view.component";
 import { EmptyGraphComponent } from "./graph/components/empty-state/graph-empty.component";
+import { DialogMovableComponent } from "./dialog/dialog-movable/dialog-movable.component";
+import { DialogImportWarningsComponent } from "./dialog/dialog-import-warnings/dialog-import-warnings.component";
 
 @NgModule({
     imports: [
@@ -108,6 +110,8 @@ import { EmptyGraphComponent } from "./graph/components/empty-state/graph-empty.
         DialogAlertComponent,
         DialogPromptComponent,
         DialogSelectComponent,
+        DialogMovableComponent,
+        DialogImportWarningsComponent,
         StationPropertiesComponent,
         DeliveryPropertiesComponent,
         DeliveriesPropertiesComponent,


### PR DESCRIPTION
The toolbar component can now receive props stating if a data upload resulted in warnings. If this prop is true, a warning symbol will be displayed next to the file name in the toolbar. When a user clicks on the symbol, a modal opens. The modal is currently empty but shall eventually display a list of warnings.

Ticket #888