### PR TITLE
Subtask 900: Adds data import warnings to warnings modal

### DIFF
--- a/src/app/main-page/container/toolbar-action-container/toolbar-action-container.component.html
+++ b/src/app/main-page/container/toolbar-action-container/toolbar-action-container.component.html
@@ -18,5 +18,6 @@
     (loadShapeFile)="onLoadShapeFile($event)"
     (downloadFile)="onDownloadFile($event)"
     (openWarningsDialog)="onOpenWarningsDialog()"
+    [dataImportHasWarnings]="dataImportHasWarnings$ | async"
 >
 </fcl-toolbar-action>

--- a/src/app/main-page/container/toolbar-action-container/toolbar-action-container.component.ts
+++ b/src/app/main-page/container/toolbar-action-container/toolbar-action-container.component.ts
@@ -153,7 +153,20 @@ export class ToolbarActionContainerComponent implements OnInit, OnDestroy {
     }
 
     onOpenWarningsDialog() {
-        this.store.dispatch(new ShowDataImportWarningsMSA());
+        let fileName = "";
+
+        this.fileName$
+            .pipe(takeWhile(() => this.componentActive))
+            .subscribe((value) => {
+                if (value && value.trim().length > 0) {
+                    fileName = value;
+                }
+            });
+
+        const description = `The following warnings occurred while importing ${fileName}`;
+        this.store.dispatch(
+            new ShowDataImportWarningsMSA({ description: description }),
+        );
     }
 
     ngOnDestroy() {

--- a/src/app/main-page/container/toolbar-action-container/toolbar-action-container.component.ts
+++ b/src/app/main-page/container/toolbar-action-container/toolbar-action-container.component.ts
@@ -34,7 +34,7 @@ import { Constants } from "@app/tracing/util/constants";
 import { ToolbarActionComponent } from "@app/main-page/presentation/toolbar-action/toolbar-action.component";
 import { IOService } from "@app/tracing/io/io.service";
 import { MAP_CONSTANTS } from "@app/tracing/util/map-constants";
-import { DialogImportWarningsComponent } from "@app/tracing/dialog/dialog-import-warnings/dialog-import-warnings.component";
+import { ShowDataImportWarningsMSA } from "@app/tracing/tracing.actions";
 
 @Component({
     selector: "fcl-toolbar-action-container",
@@ -46,10 +46,13 @@ export class ToolbarActionContainerComponent implements OnInit, OnDestroy {
     toolbarActionComponent: ToolbarActionComponent;
 
     isModelLoaded$ = this.store.select(tracingSelectors.selectIsModelLoaded);
-    tracingActive$ = this.store.pipe(select(tracingSelectors.getTracingActive));
-    graphEditorActive$ = this.store.pipe(select(fromEditor.isActive));
-    currentUser$ = this.store.pipe(select(fromUser.getCurrentUser));
-    fileName$ = this.store.pipe(select(tracingSelectors.selectSourceFileName));
+    tracingActive$ = this.store.select(tracingSelectors.getTracingActive);
+    graphEditorActive$ = this.store.select(fromEditor.isActive);
+    currentUser$ = this.store.select(fromUser.getCurrentUser);
+    fileName$ = this.store.select(tracingSelectors.selectSourceFileName);
+    dataImportHasWarnings$ = this.store.select(
+        tracingSelectors.selectImportHasWarnings,
+    );
 
     graphSettings: GraphSettings;
     hasGisInfo = false;
@@ -150,10 +153,7 @@ export class ToolbarActionContainerComponent implements OnInit, OnDestroy {
     }
 
     onOpenWarningsDialog() {
-        this.dialog.open(DialogImportWarningsComponent, {
-            // to do: add issues
-            data: "add issues here",
-        });
+        this.store.dispatch(new ShowDataImportWarningsMSA());
     }
 
     ngOnDestroy() {

--- a/src/app/main-page/container/toolbar-action-container/toolbar-action-container.component.ts
+++ b/src/app/main-page/container/toolbar-action-container/toolbar-action-container.component.ts
@@ -153,20 +153,7 @@ export class ToolbarActionContainerComponent implements OnInit, OnDestroy {
     }
 
     onOpenWarningsDialog() {
-        let fileName = "";
-
-        this.fileName$
-            .pipe(takeWhile(() => this.componentActive))
-            .subscribe((value) => {
-                if (value && value.trim().length > 0) {
-                    fileName = value;
-                }
-            });
-
-        const description = `The following warnings occurred while importing ${fileName}`;
-        this.store.dispatch(
-            new ShowDataImportWarningsMSA({ description: description }),
-        );
+        this.store.dispatch(new ShowDataImportWarningsMSA());
     }
 
     ngOnDestroy() {

--- a/src/app/main-page/presentation/toolbar-action/toolbar-action.component.ts
+++ b/src/app/main-page/presentation/toolbar-action/toolbar-action.component.ts
@@ -58,7 +58,7 @@ export class ToolbarActionComponent implements OnChanges {
     @Input() graphEditorActive: boolean;
     @Input() currentUser: User;
     @Input() fileName: string | null = null;
-    @Input() dataImportHasWarnings: boolean;
+    @Input() dataImportHasWarnings: boolean = false;
     @Output() toggleRightSidebar = new EventEmitter<boolean>();
     @Output() loadModelFile = new EventEmitter<FileList>();
     @Output() loadShapeFile = new EventEmitter<FileList>();

--- a/src/app/main-page/presentation/toolbar-action/toolbar-action.component.ts
+++ b/src/app/main-page/presentation/toolbar-action/toolbar-action.component.ts
@@ -58,7 +58,7 @@ export class ToolbarActionComponent implements OnChanges {
     @Input() graphEditorActive: boolean;
     @Input() currentUser: User;
     @Input() fileName: string | null = null;
-    @Input() dataImportHasWarnings: boolean = false;
+    @Input() dataImportHasWarnings: boolean;
     @Output() toggleRightSidebar = new EventEmitter<boolean>();
     @Output() loadModelFile = new EventEmitter<FileList>();
     @Output() loadShapeFile = new EventEmitter<FileList>();

--- a/src/app/tracing/dialog/dialog-import-warnings/dialog-import-warnings.component.html
+++ b/src/app/tracing/dialog/dialog-import-warnings/dialog-import-warnings.component.html
@@ -2,15 +2,14 @@
     <div mat-dialog-content>
         <mat-card>
             <mat-card-title>
-                <span>Data import warnings</span>
+                <h2>Data import warnings</h2>
             </mat-card-title>
             <mat-card-content>
-                <span *ngIf="fileName">
-                    The following warnings occurred during the import of file
-                    {{ fileName }}
+                <span>
+                    {{ description }}
                 </span>
-                <ul *ngFor="let warning of warnings">
-                    <li>{{ warning }}</li>
+                <ul>
+                    <li *ngFor="let warning of warnings">{{ warning }}</li>
                 </ul>
             </mat-card-content>
         </mat-card>

--- a/src/app/tracing/dialog/dialog-import-warnings/dialog-import-warnings.component.html
+++ b/src/app/tracing/dialog/dialog-import-warnings/dialog-import-warnings.component.html
@@ -5,7 +5,14 @@
                 <span>Data import warnings</span>
             </mat-card-title>
             <mat-card-content>
-                {{ data }}
+                <span *ngIf="fileName">
+                    The following warnings occurred during the import of file
+                    {{ fileName }}
+                </span>
+                <ul *ngFor="let warning of warnings">
+                    <li *ngIf="warning.trim().length > 0">{{ warning }}</li>
+                    <li *ngIf="warning.trim().length === 0">unknown warning</li>
+                </ul>
             </mat-card-content>
         </mat-card>
     </div>

--- a/src/app/tracing/dialog/dialog-import-warnings/dialog-import-warnings.component.html
+++ b/src/app/tracing/dialog/dialog-import-warnings/dialog-import-warnings.component.html
@@ -10,8 +10,7 @@
                     {{ fileName }}
                 </span>
                 <ul *ngFor="let warning of warnings">
-                    <li *ngIf="warning.trim().length > 0">{{ warning }}</li>
-                    <li *ngIf="warning.trim().length === 0">unknown warning</li>
+                    <li>{{ warning }}</li>
                 </ul>
             </mat-card-content>
         </mat-card>

--- a/src/app/tracing/dialog/dialog-import-warnings/dialog-import-warnings.component.ts
+++ b/src/app/tracing/dialog/dialog-import-warnings/dialog-import-warnings.component.ts
@@ -1,11 +1,24 @@
 import { Component, Inject } from "@angular/core";
 import { MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA } from "@angular/material/legacy-dialog";
 
+export interface DialogImportWarningsData {
+    fileName: string | null;
+    warnings: string[];
+}
+
 @Component({
     selector: "fcl-dialog-import-warnings",
     templateUrl: "./dialog-import-warnings.component.html",
     styleUrls: ["./dialog-import-warnings.component.scss"],
 })
 export class DialogImportWarningsComponent {
-    constructor(@Inject(MAT_DIALOG_DATA) public data: any) {}
+    fileName: string | null;
+    warnings: string[];
+
+    constructor(
+        @Inject(MAT_DIALOG_DATA) public data: DialogImportWarningsData,
+    ) {
+        this.fileName = data.fileName;
+        this.warnings = data.warnings;
+    }
 }

--- a/src/app/tracing/dialog/dialog-import-warnings/dialog-import-warnings.component.ts
+++ b/src/app/tracing/dialog/dialog-import-warnings/dialog-import-warnings.component.ts
@@ -2,7 +2,7 @@ import { Component, Inject } from "@angular/core";
 import { MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA } from "@angular/material/legacy-dialog";
 
 export interface DialogImportWarningsData {
-    fileName: string | null;
+    description: string | null;
     warnings: string[];
 }
 
@@ -12,13 +12,13 @@ export interface DialogImportWarningsData {
     styleUrls: ["./dialog-import-warnings.component.scss"],
 })
 export class DialogImportWarningsComponent {
-    fileName: string | null;
+    description: string | null;
     warnings: string[];
 
     constructor(
         @Inject(MAT_DIALOG_DATA) public data: DialogImportWarningsData,
     ) {
-        this.fileName = data.fileName;
+        this.description = data.description;
         this.warnings = data.warnings;
     }
 }

--- a/src/app/tracing/state/tracing.selectors.ts
+++ b/src/app/tracing/state/tracing.selectors.ts
@@ -449,3 +449,13 @@ export const selectDeliveryFilterState = createSelector(
         filterTableState: deliveryFilterSettings,
     }),
 );
+
+export const selectImportWarnings = createSelector(
+    getFclData,
+    (fclData) => fclData.importWarnings,
+);
+
+export const selectImportHasWarnings = createSelector(
+    selectImportWarnings,
+    (importWarnings) => importWarnings.length > 0,
+);

--- a/src/app/tracing/tracing.actions.ts
+++ b/src/app/tracing/tracing.actions.ts
@@ -31,6 +31,7 @@ export enum TracingActionTypes {
     FocusGraphElementSSA = "[Graph] Focus Graph Element",
     SetLastUnchangedJsonDataExtractMSA = "[Tracing] Set Last Unchanged JsonData Extract",
     SetStationPositionsAndLayoutMSA = "[Tracing] Set Station Positions And Layout MSA",
+    ShowDataImportWarningsMSA = "[Data Import] Show warnings",
 }
 
 export class ClearTraceMSA implements Action {
@@ -147,6 +148,10 @@ export class SetStationPositionsAndLayoutMSA implements Action {
     ) {}
 }
 
+export class ShowDataImportWarningsMSA implements Action {
+    readonly type = TracingActionTypes.ShowDataImportWarningsMSA;
+}
+
 export type TracingActions =
     | ClearTraceMSA
     | ClearKillContaminationsMSA
@@ -163,4 +168,5 @@ export type TracingActions =
     | FocusDeliverySSA
     | FocusGraphElementSSA
     | SetLastUnchangedJsonDataExtractMSA
-    | SetStationPositionsAndLayoutMSA;
+    | SetStationPositionsAndLayoutMSA
+    | ShowDataImportWarningsMSA;

--- a/src/app/tracing/tracing.actions.ts
+++ b/src/app/tracing/tracing.actions.ts
@@ -150,6 +150,7 @@ export class SetStationPositionsAndLayoutMSA implements Action {
 
 export class ShowDataImportWarningsMSA implements Action {
     readonly type = TracingActionTypes.ShowDataImportWarningsMSA;
+    constructor(public payload: { description: string }) {}
 }
 
 export type TracingActions =

--- a/src/app/tracing/tracing.actions.ts
+++ b/src/app/tracing/tracing.actions.ts
@@ -150,7 +150,6 @@ export class SetStationPositionsAndLayoutMSA implements Action {
 
 export class ShowDataImportWarningsMSA implements Action {
     readonly type = TracingActionTypes.ShowDataImportWarningsMSA;
-    constructor(public payload: { description: string }) {}
 }
 
 export type TracingActions =

--- a/src/app/tracing/tracing.effects.ts
+++ b/src/app/tracing/tracing.effects.ts
@@ -696,10 +696,20 @@ export class TracingEffects {
                     this.store.pipe(
                         select(tracingSelectors.selectImportWarnings),
                     ),
+                    this.store.pipe(
+                        select(tracingSelectors.selectSourceFileName),
+                    ),
                 ),
-                mergeMap(([action, warnings]) => {
+                mergeMap(([, warnings, fileName]) => {
+                    const fileNameExists =
+                        fileName && fileName.trim().length > 0;
+                    const description =
+                        "The following warnings occurred while importing";
+
                     const data: DialogImportWarningsData = {
-                        description: action.payload.description,
+                        description: fileNameExists
+                            ? `${description} ${fileName}`
+                            : description,
                         warnings: warnings,
                     };
 

--- a/src/app/tracing/tracing.effects.ts
+++ b/src/app/tracing/tracing.effects.ts
@@ -32,6 +32,10 @@ import { EditHighlightingService } from "./configuration/edit-highlighting.servi
 import { GraphService } from "./graph/graph.service";
 import { TableService } from "./services/table.service";
 import { IOService } from "./io/io.service";
+import {
+    DialogImportWarningsComponent,
+    DialogImportWarningsData,
+} from "./dialog/dialog-import-warnings/dialog-import-warnings.component";
 
 @Injectable()
 export class TracingEffects {
@@ -679,5 +683,36 @@ export class TracingEffects {
                 ),
             ),
         ),
+    );
+
+    showDataImportWarningsMSA$ = createEffect(
+        () =>
+            this.actions$.pipe(
+                ofType<tracingEffectActions.ShowDataImportWarningsMSA>(
+                    tracingEffectActions.TracingActionTypes
+                        .ShowDataImportWarningsMSA,
+                ),
+                withLatestFrom(
+                    this.store.pipe(
+                        select(tracingSelectors.selectImportWarnings),
+                    ),
+                    this.store.pipe(
+                        select(tracingSelectors.selectSourceFileName),
+                    ),
+                ),
+                mergeMap(([, warnings, fileName]) => {
+                    const data: DialogImportWarningsData = {
+                        fileName: fileName,
+                        warnings: warnings,
+                    };
+
+                    this.dialogService.open(DialogImportWarningsComponent, {
+                        data: data,
+                    });
+
+                    return EMPTY;
+                }),
+            ),
+        { dispatch: false },
     );
 }

--- a/src/app/tracing/tracing.effects.ts
+++ b/src/app/tracing/tracing.effects.ts
@@ -696,13 +696,10 @@ export class TracingEffects {
                     this.store.pipe(
                         select(tracingSelectors.selectImportWarnings),
                     ),
-                    this.store.pipe(
-                        select(tracingSelectors.selectSourceFileName),
-                    ),
                 ),
-                mergeMap(([, warnings, fileName]) => {
+                mergeMap(([action, warnings]) => {
                     const data: DialogImportWarningsData = {
-                        fileName: fileName,
+                        description: action.payload.description,
                         warnings: warnings,
                     };
 


### PR DESCRIPTION
If warnings occurred during data import, a red warning sign is visible next to the file name. Clicking on that warning sign opens a dialog displaying a list of warnings. Warnings without text will be displayed as 'unknown warning'."

Ticket #900