### PR TITLE
Ticket 849: Makes single and multiple deliveries props dialogues movable

### DIFF
--- a/src/app/tracing/dialog/deliveries-properties/deliveries-properties.component.html
+++ b/src/app/tracing/dialog/deliveries-properties/deliveries-properties.component.html
@@ -1,102 +1,56 @@
-<h1 class="title" matDialogTitle>
-    <span>Delivery Properties</span>
-</h1>
+<fcl-dialog-movable>
+    <h1 class="title" matDialogTitle>
+        <span>Delivery Properties</span>
+    </h1>
 
-<mat-form-field floatLabel="never" class="overall-column-filter">
-    <input
-        type="search"
-        placeholder="Filter"
-        aria-label="Number"
-        matInput
-        [(ngModel)]="rootFilter.filterText"
-        name="rootFilter"
-        (keyup)="updateRowsAndOptions()"
-        (reset)="resetFilter()"
-    />
-</mat-form-field>
+    <mat-form-field floatLabel="never" class="overall-column-filter">
+        <input
+            type="search"
+            placeholder="Filter"
+            aria-label="Number"
+            matInput
+            [(ngModel)]="rootFilter.filterText"
+            name="rootFilter"
+            (keyup)="updateRowsAndOptions()"
+            (reset)="resetFilter()"
+        />
+    </mat-form-field>
 
-<ngx-datatable
-    fclNgxDatatableScrollFix
-    class="material fcl-datatable fcl-deliveries-properties-table"
-    [rows]="filteredRows"
-    [columns]="columns"
-    [columnMode]="'standard'"
-    [headerHeight]="80"
-    [rowHeight]="ROW_HEIGHT"
-    [footerHeight]="50"
-    [scrollbarV]="true"
-    [scrollbarH]="true"
-    [swapColumns]="false"
-    [selected]="selectedRows"
-    [selectionType]="'multi'"
-    (select)="onRowSelectionChange($event)"
->
-    <ngx-datatable-column
-        name="'H'"
-        prop="hColor"
-        [minWidth]="40"
-        [maxWidth]="40"
-        [width]="40"
-        [sortable]="true"
-        [canAutoResize]="false"
-        [draggable]="false"
-        [resizeable]="false"
-        headerClass="highlighting-column"
+    <ngx-datatable
+        fclNgxDatatableScrollFix
+        class="material fcl-datatable fcl-deliveries-properties-table"
+        [rows]="filteredRows"
+        [columns]="columns"
+        [columnMode]="'standard'"
+        [headerHeight]="80"
+        [rowHeight]="ROW_HEIGHT"
+        [footerHeight]="50"
+        [scrollbarV]="true"
+        [scrollbarH]="true"
+        [swapColumns]="false"
+        [selected]="selectedRows"
+        [selectionType]="'multi'"
+        (select)="onRowSelectionChange($event)"
     >
-        <ng-template
-            let-sort="sortFn"
-            let-sortDir="sortDir"
-            ngx-datatable-header-template
+        <ngx-datatable-column
+            name="'H'"
+            prop="hColor"
+            [minWidth]="40"
+            [maxWidth]="40"
+            [width]="40"
+            [sortable]="true"
+            [canAutoResize]="false"
+            [draggable]="false"
+            [resizeable]="false"
+            headerClass="highlighting-column"
         >
-            <span class="fcl-header-sort-span pointable" (click)="sort()">
-                H
-                <span
-                    *ngIf="sortDir !== 'asc' && sortDir !== 'desc'"
-                    class="sort-btn datatable-icon-expand"
-                ></span>
-                <span
-                    *ngIf="sortDir === 'asc'"
-                    class="sort-btn sort-asc datatable-icon-up"
-                ></span>
-                <span
-                    *ngIf="sortDir === 'desc'"
-                    class="sort-btn sort-desc datatable-icon-down"
-                ></span>
-            </span>
-        </ng-template>
-
-        <ng-template
-            let-value="value"
-            let-row="row"
-            ngx-datatable-cell-template
-        >
-            <div
-                [ngStyle]="{ background: row.hColor }"
-                class="highlighting-div"
-            ></div>
-        </ng-template>
-    </ngx-datatable-column>
-
-    <ngx-datatable-column
-        *ngFor="let column of columns"
-        name="{{ column.name }}"
-        prop="{{ column.prop }}"
-        [minWidth]="20"
-        [sortable]="true"
-        [canAutoResize]="false"
-        [draggable]="true"
-        [resizeable]="true"
-        headerClass="filter-header"
-    >
-        <ng-template
-            let-column="column"
-            let-sort="sortFn"
-            let-sortDir="sortDir"
-            ngx-datatable-header-template
-        >
-            <div class="draggable">
+            <ng-template
+                let-sort="sortFn"
+                let-sortDir="sortDir"
+                ngx-datatable-header-template
+            >
                 <span class="fcl-header-sort-span pointable" (click)="sort()">
-                    {{ column.name }}
+                    H
                     <span
                         *ngIf="sortDir !== 'asc' && sortDir !== 'desc'"
                         class="sort-btn datatable-icon-expand"
@@ -108,67 +62,120 @@
                     <span
                         *ngIf="sortDir === 'desc'"
                         class="sort-btn sort-desc datatable-icon-down"
-                    ></span> </span
-                ><br />
+                    ></span>
+                </span>
+            </ng-template>
 
-                <mat-form-field floatLabel="never">
-                    <input
-                        type="search"
-                        placeholder="Filter"
-                        aria-label="Number"
-                        matInput
-                        tabindex="-1"
-                        [(ngModel)]="propToColumnMap[column.prop].filterText"
-                        id="{{ column.prop }}"
-                        [matAutocomplete]="auto"
-                        (keyup)="updateRowsAndOptions()"
-                        (reset)="resetFilter()"
-                    />
+            <ng-template
+                let-value="value"
+                let-row="row"
+                ngx-datatable-cell-template
+            >
+                <div
+                    [ngStyle]="{ background: row.hColor }"
+                    class="highlighting-div"
+                ></div>
+            </ng-template>
+        </ngx-datatable-column>
 
-                    <mat-autocomplete
-                        #auto="matAutocomplete"
-                        (optionSelected)="updateRowsAndOptions()"
-                    >
-                        <mat-option
-                            *ngFor="
-                                let option of propToColumnMap[column.prop]
-                                    .filteredOptions
-                            "
-                            [value]="option"
-                        >
-                            {{ option }}
-                        </mat-option>
-                    </mat-autocomplete>
-                </mat-form-field>
-            </div>
-        </ng-template>
-    </ngx-datatable-column>
-
-    <ngx-datatable-footer class="datatable-footer">
-        <ng-template
-            ngx-datatable-footer-template
-            let-rowCount="rowCount"
-            let-pageSize="pageSize"
-            let-selectedCount="selectedCount"
-            let-curPage="curPage"
-            let-offset="offset"
-            let-isVisible="isVisible"
+        <ngx-datatable-column
+            *ngFor="let column of columns"
+            name="{{ column.name }}"
+            prop="{{ column.prop }}"
+            [minWidth]="20"
+            [sortable]="true"
+            [canAutoResize]="false"
+            [draggable]="true"
+            [resizeable]="true"
+            headerClass="filter-header"
         >
-            <div class="datatable-footer-inner selected-count">
-                <div class="page-count">
-                    <span>
-                        {{ selectedCount.toLocaleString() }} selected /
-                    </span>
-                    {{ rowCount.toLocaleString() }} total
-                </div>
-            </div>
-        </ng-template>
-    </ngx-datatable-footer>
-</ngx-datatable>
+            <ng-template
+                let-column="column"
+                let-sort="sortFn"
+                let-sortDir="sortDir"
+                ngx-datatable-header-template
+            >
+                <div class="draggable">
+                    <span
+                        class="fcl-header-sort-span pointable"
+                        (click)="sort()"
+                    >
+                        {{ column.name }}
+                        <span
+                            *ngIf="sortDir !== 'asc' && sortDir !== 'desc'"
+                            class="sort-btn datatable-icon-expand"
+                        ></span>
+                        <span
+                            *ngIf="sortDir === 'asc'"
+                            class="sort-btn sort-asc datatable-icon-up"
+                        ></span>
+                        <span
+                            *ngIf="sortDir === 'desc'"
+                            class="sort-btn sort-desc datatable-icon-down"
+                        ></span> </span
+                    ><br />
 
-<div mat-dialog-actions>
-    <button mat-button matDialogClose>OK</button>
-    <button mat-button matDialogClose (click)="applySelection()">
-        Apply Selection & Close
-    </button>
-</div>
+                    <mat-form-field floatLabel="never">
+                        <input
+                            type="search"
+                            placeholder="Filter"
+                            aria-label="Number"
+                            matInput
+                            tabindex="-1"
+                            [(ngModel)]="
+                                propToColumnMap[column.prop].filterText
+                            "
+                            id="{{ column.prop }}"
+                            [matAutocomplete]="auto"
+                            (keyup)="updateRowsAndOptions()"
+                            (reset)="resetFilter()"
+                        />
+
+                        <mat-autocomplete
+                            #auto="matAutocomplete"
+                            (optionSelected)="updateRowsAndOptions()"
+                        >
+                            <mat-option
+                                *ngFor="
+                                    let option of propToColumnMap[column.prop]
+                                        .filteredOptions
+                                "
+                                [value]="option"
+                            >
+                                {{ option }}
+                            </mat-option>
+                        </mat-autocomplete>
+                    </mat-form-field>
+                </div>
+            </ng-template>
+        </ngx-datatable-column>
+
+        <ngx-datatable-footer class="datatable-footer">
+            <ng-template
+                ngx-datatable-footer-template
+                let-rowCount="rowCount"
+                let-pageSize="pageSize"
+                let-selectedCount="selectedCount"
+                let-curPage="curPage"
+                let-offset="offset"
+                let-isVisible="isVisible"
+            >
+                <div class="datatable-footer-inner selected-count">
+                    <div class="page-count">
+                        <span>
+                            {{ selectedCount.toLocaleString() }} selected /
+                        </span>
+                        {{ rowCount.toLocaleString() }} total
+                    </div>
+                </div>
+            </ng-template>
+        </ngx-datatable-footer>
+    </ngx-datatable>
+
+    <div mat-dialog-actions>
+        <button mat-button matDialogClose>Close</button>
+        <button mat-button matDialogClose (click)="applySelection()">
+            Apply Selection & Close
+        </button>
+    </div>
+</fcl-dialog-movable>

--- a/src/app/tracing/dialog/delivery-properties/delivery-properties.component.html
+++ b/src/app/tracing/dialog/delivery-properties/delivery-properties.component.html
@@ -1,45 +1,49 @@
-<div mat-dialog-content>
-    <mat-card class="mat-card">
-        <!--suppress HtmlUnknownTag -->
-        <mat-card-title>
-            <span>{{ data.delivery.name }}</span>
-        </mat-card-title>
-        <mat-card-content>
-            <table class="property-table">
-                <tr *ngFor="let prop of vipProperties">
-                    <td>{{ properties[prop].label }}</td>
-                    <td>{{ properties[prop].value }}</td>
-                </tr>
-                <tr *ngIf="!otherPropertiesHidden">
-                    <td
-                        colspan="2"
-                        class="fcl-delivery-properties-horizontal-line-cell"
+<fcl-dialog-movable>
+    <div mat-dialog-content>
+        <mat-card class="mat-card">
+            <!--suppress HtmlUnknownTag -->
+            <mat-card-title>
+                <span>{{ data.delivery.name }}</span>
+            </mat-card-title>
+            <mat-card-content>
+                <table class="property-table">
+                    <tr *ngFor="let prop of vipProperties">
+                        <td>{{ properties[prop].label }}</td>
+                        <td>{{ properties[prop].value }}</td>
+                    </tr>
+                    <tr *ngIf="!otherPropertiesHidden">
+                        <td
+                            colspan="2"
+                            class="fcl-delivery-properties-horizontal-line-cell"
+                        >
+                            <hr
+                                class="fcl-delivery-properties-horizontal-line"
+                            />
+                        </td>
+                    </tr>
+                    <tr
+                        *ngFor="
+                            let prop of !otherPropertiesHidden
+                                ? getOtherPropertiesOri()
+                                : []
+                        "
                     >
-                        <hr class="fcl-delivery-properties-horizontal-line" />
-                    </td>
-                </tr>
-                <tr
-                    *ngFor="
-                        let prop of !otherPropertiesHidden
-                            ? getOtherPropertiesOri()
-                            : []
-                    "
+                        <td>{{ properties[prop].label }}</td>
+                        <td>{{ properties[prop].value }}</td>
+                    </tr>
+                </table>
+                <button
+                    mat-button
+                    *ngIf="otherProperties.length > 0"
+                    (click)="toggleOtherProperties()"
                 >
-                    <td>{{ properties[prop].label }}</td>
-                    <td>{{ properties[prop].value }}</td>
-                </tr>
-            </table>
-            <button
-                mat-button
-                *ngIf="otherProperties.length > 0"
-                (click)="toggleOtherProperties()"
-            >
-                <span *ngIf="otherPropertiesHidden">More properties</span>
-                <span *ngIf="!otherPropertiesHidden">Less properties</span>
-            </button>
-        </mat-card-content>
-    </mat-card>
-</div>
-<div mat-dialog-actions>
-    <button mat-button cdkFocusInitial matDialogClose>OK</button>
-</div>
+                    <span *ngIf="otherPropertiesHidden">More properties</span>
+                    <span *ngIf="!otherPropertiesHidden">Less properties</span>
+                </button>
+            </mat-card-content>
+        </mat-card>
+    </div>
+    <div mat-dialog-actions>
+        <button mat-button cdkFocusInitial matDialogClose>Close</button>
+    </div>
+</fcl-dialog-movable>


### PR DESCRIPTION
Both dialogue types now use the fcl-dialoge-movable component. The OK button was renamed to 'close'.

Ticket #849