### PR TITLE
Fix bug causing stations to be registered twice.

### DIFF
--- a/src/app/tracing/io/data-importer/xlsx-import/all-in-one/importer.ts
+++ b/src/app/tracing/io/data-importer/xlsx-import/all-in-one/importer.ts
@@ -162,10 +162,6 @@ export class AllInOneImporter implements XlsxImporter {
                 addIssueCallback,
             );
 
-            if (stationRow.extId) {
-                externalIdRegister.add(stationRow.extId);
-            }
-
             if (!rowIsInvalid) {
                 const longUniqueId = getLongUniqueStationId(stationRow);
                 if (longUniqueId2RowIndexMap.has(longUniqueId)) {


### PR DESCRIPTION
Stations where registered twice, which caused deliveries to not consider them valid source or target. Because of this all deliveries where ommitted with warning in import.

Ticket: #926