### PR TITLE
Ticket 804: Fixes text overflow in stations properties svg

### DIFF
--- a/src/app/tracing/dialog/station-properties/station-properties.component.html
+++ b/src/app/tracing/dialog/station-properties/station-properties.component.html
@@ -43,7 +43,11 @@
         </mat-card>
         <mat-card>
             <mat-card-content>
-                <div #inOutConnector></div>
+                <div
+                    #inOutConnector
+                    #tooltip="matTooltip"
+                    [matTooltip]="tooltipContent"
+                ></div>
             </mat-card-content>
         </mat-card>
     </div>

--- a/src/material-style.scss
+++ b/src/material-style.scss
@@ -2,6 +2,8 @@
 
 .mat-tooltip {
     font-size: 14px !important;
+    white-space: pre-line;
+    word-break: break-word;
 }
 
 .mat-toolbar {


### PR DESCRIPTION
Text in svg in stations properties modal will now be truncated if it is longer than the rectangle it is rendered in. When hovering over a rectangle, a tooltip shows the entire text content.

Ticket #804