### PR TITLE
Ticket #949: Changes color of warning toaster

### DIFF
--- a/src/material-style.scss
+++ b/src/material-style.scss
@@ -36,25 +36,25 @@
 }
 
 .snackbar-error {
-    background-color: #c62828;
-    font-weight: 500;
+    background-color: #c62828 !important;
+    font-weight: 500 !important;
 
     .mat-button-wrapper {
-        color: white;
+        color: white !important;
     }
 }
 
 .snackbar-success {
-    background-color: #c8e6c9;
-    color: black;
+    background-color: #c8e6c9 !important;
+    color: black !important;
 }
 
 .snackbar-warn {
-    background-color: #fff9c4;
-    color: black;
+    background-color: rgb(255 221 0) !important;
+    color: black !important;
 }
 
 .snackbar-info {
-    background-color: #bbdefb;
-    color: black;
+    background-color: #bbdefb !important;
+    color: black !important;
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -46,26 +46,6 @@ body {
     text-align: center;
 }
 
-.snackbar-error {
-    background-color: #c62828;
-    font-weight: 500;
-}
-
-.snackbar-success {
-    background-color: #c8e6c9;
-    color: black;
-}
-
-.snackbar-warn {
-    background-color: #fff9c4;
-    color: black;
-}
-
-.snackbar-info {
-    background-color: #bbdefb;
-    color: black;
-}
-
 // improves multiline error messages
 fcl-register,
 fcl-reset {


### PR DESCRIPTION
Warning toaster has a stronger background color now to improve visibility. The duplicate styles for the snackbar toasters in styles.scss have been removed. The original styles in material-styles.scss have been marked with !important, to ensure that they are not overwritten.

Ticket #949